### PR TITLE
Mock api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_XRapidAPIKey= 
-NEXT_PUBLIC_XRapidAPIHost= api-nba-v1.p.rapidapi.com
+XRapidAPIKey= 
+XRapidAPIHost= api-nba-v1.p.rapidapi.com

--- a/MockApiResponse.mjs
+++ b/MockApiResponse.mjs
@@ -1,0 +1,33 @@
+import {promises as fs} from "fs";
+import path from "path";
+
+export default async function getStaticProps() {
+  const filePath = path.join(process.cwd(), "app/components/Scores.tsx");
+  let content = await fs.readFile(filePath, "utf8");
+
+  function modifyFileContent(content) {
+    content = content.replace(
+      /const fetcher = \(url: string\) => fetch\(url\)\.then\(\(res\) => res\.json\(\)\);[\s\S]*?const games: Game\[\] = data\?\.response/gm,
+      "// Deleted the SWR data fetching block"
+    );
+
+    content = content.replace(
+      /\{isLoading && <div>Scores are loading!<\/div>\}/g,
+      "{/* {isLoading && <div>Scores are loading!</div>} */}"
+    );
+
+    content = content.replace(/games(?!:)(?!\s)((?!\?date))/gm, "devModeGames");
+
+    return content;
+  }
+
+  const modifiedContent = modifyFileContent(content);
+
+  // Write the modified content back to the file
+  await fs.writeFile(filePath, modifiedContent);
+
+  console.log("Modified app/components/Scores.tsx successfully.");
+}
+
+// Run the function immediately
+getStaticProps();

--- a/README.md
+++ b/README.md
@@ -27,35 +27,25 @@ Design: https://www.figma.com/file/AQL6ywEUiKkconAcaX5upM/NBA-Website-(Community
 
 ### Local Setup
 
-To run this locally on your machine, copy the contents of `.env.example`.
+To run this locally on your machine, install the dependencies with your package manager of choice. I'm using NPM, which means I run `npm i`.
+
+To use the API to grab data for the app, copy the contents of `.env.example`.
 
 Then create your own `.env.local` file, add in what you copied, and signup for the [API](https://rapidapi.com/api-sports/api/api-nba/).
 
 Add your API keys by finding and copying them in the Rapid API docs.
 
-<!-- ### Mimic an API Response
+Run the app by running `npm run dev` in your terminal. Then open the app at 
 
-If you'd like to see what the scores UI looks like without signing up for the API, or test the view in dev mode, here's how:
+### Mock an API Response
 
-In `app/components/Scores.tsx`, comment out the last line of the useEffect function where fetchData is called:
+If you'd like to see what the scores UI looks like without signing up for the API, or test the view in dev mode, run this in your terminal:
 
-```ts
-  useEffect(() => {
-    async function fetchData() {
-  // useEffect redacted for brevity
-  // fetchData();
-  }, [dateSelected]);
-```
+`npm run mock-api`
 
-Then scroll down or use the find function to get to where you find `gameData?.map`. Change `gameData` to `devModeData`, like so:
+This runs a file at the root called `MockApiResponse.mjs` that edits `app/components/Scores.tsx` to no longer call the API and use `exampleResponse.json` as your data.
 
-```ts
- {devModeData?.map((game) => {
-        return // inner map function logic)
-})}
-```
-
-After you make these changes and run the app with `npm run dev`, you'll be using `exampleResponse.json` as your data instead of making a call to the API. -->
+To undo these changes, make sure you have `app/components/Scores.tsx` open before you run `npm run mock-api`. Then in `app/components/Scores.tsx` you can undo the changes the script makes.
 
 ## Contact
 

--- a/app/components/Scores.tsx
+++ b/app/components/Scores.tsx
@@ -67,13 +67,15 @@ const Scores = ({showScores, dateSelected}: Scores) => {
           <Fragment key={game.id}>
             <div className="flex flex-row justify-evenly mt-2">
               <div className="flex flex-col items-center">
-                <img
-                  src={game.teams.home.logo}
-                  onError={noImage}
-                  className="object-contain w-12 h-12"
-                  alt={`${game.teams.home.name} logo`}
-                />
-                <p className="mt-2">{game.teams.home.name}</p>
+                <div>
+                  <img
+                    src={game.teams.home.logo}
+                    onError={noImage}
+                    className="block max-w-12 h-12"
+                    alt={`${game.teams.home.name} logo`}
+                  />
+                </div>
+                <p className="mt-2">{game.teams.home.name.split(" ").pop()}</p>
                 <h2 className="mb-2">
                   {showScores && game.scores.home.total !== null
                     ? `${game.scores.home.total}`
@@ -81,13 +83,15 @@ const Scores = ({showScores, dateSelected}: Scores) => {
                 </h2>
               </div>
               <div className="flex flex-col items-center">
-                <img
-                  src={game.teams.away.logo}
-                  onError={noImage}
-                  className="object-contain w-12 h-12"
-                  alt={`${game.teams.away.name} logo`}
-                />
-                <p className="mt-2">{game.teams.away.name}</p>
+                <div>
+                  <img
+                    src={game.teams.away.logo}
+                    onError={noImage}
+                    className="block max-w-12 h-12"
+                    alt={`${game.teams.away.name} logo`}
+                  />
+                </div>
+                <p className="mt-2">{game.teams.away.name.split(" ").pop()}</p>
                 <h2 className="mb-2">
                   {showScores && game.scores.away.total !== null
                     ? `${game.scores.away.total}`

--- a/app/components/Scores.tsx
+++ b/app/components/Scores.tsx
@@ -57,11 +57,12 @@ const Scores = ({showScores, dateSelected}: Scores) => {
 
   return (
     <div>
-      {dateSelected && games?.length === 0 && (
+      {!isLoading && dateSelected && games?.length === 0 && (
         <h1>No 🏀 games on {format(dateSelected, "PPP")}</h1>
       )}
       {isLoading && <div>Scores are loading!</div>}
-      {/* to test by calling the API use games as what you map through, otherwise use devModeGames */}
+      {/* to test by calling the API use games as what you map through, otherwise run this in your terminal:
+          npm run mock-api */}
       {games?.map((game) => {
         return (
           <Fragment key={game.id}>

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "mock-api": "npx ts-node MockApiResponse.mjs"
   },
   "dependencies": {
     "@heroicons/react": "^2.1.1",


### PR DESCRIPTION
Add `MockApiResponse.mjs` and a command `npm run mock-api` script to make it easier to mock an api response. Change env variable names in `.env.example`. Working on making logos the same size, still a WIP.

closes #44 
closes #43 