### PR TITLE
center gameCard if there's only one game

### DIFF
--- a/src/routes/games/Games.tsx
+++ b/src/routes/games/Games.tsx
@@ -78,7 +78,13 @@ const Games = () => {
         <div className="flex justify-center text-lg">No games today</div>
       ) : (
         <section className="px-4 py-6">
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 max-w-4xl mx-auto">
+          <div
+            className={`grid gap-8 max-w-4xl mx-auto ${
+              games.length === 1
+                ? "grid-cols-1 place-items-center"
+                : "grid-cols-1 lg:grid-cols-2"
+            }`}
+          >
             {games.map((gamedata) => (
               <GameCard
                 key={gamedata.gameId}


### PR DESCRIPTION
closes #120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Improved the layout of game cards so that when only one game is displayed, it is centered in a single column for better visual alignment. Multiple games continue to use the standard grid layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->