### PR TITLE
add word results to reveal round switch on desktop

### DIFF
--- a/src/components/PlayoffBracketFlow.tsx
+++ b/src/components/PlayoffBracketFlow.tsx
@@ -189,7 +189,7 @@ function PlayoffBracketFlowInner({ playoffPicture, season }: PlayoffBracketFlowP
               UNSAFE_className="origin-left scale-75 sm:scale-100"
             >
               <div className="dark:text-slate-50 text-neutral-950">
-                {isRevealed ? `Hide ${roundName}` : `Show ${roundName}`}
+                {isRevealed ? `Hide ${roundName}` : `Show ${roundName} Results`}
               </div>
             </Switch>
           );


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated playoff bracket round control labels to display "Show [Round] Results" for unrevealed rounds, providing clearer guidance to users about the action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->