### PR TITLE
Fix playoff series winner to use WL flag instead of PTS (1984 result + Suns-Jazz tie)

### DIFF
--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -325,6 +325,31 @@ def apply_rounds_to_games(games):
     )
 
 
+def determine_winner(home_team, away_team, home_score, away_score):
+    """
+    Determine the winning team for a game.
+
+    The NBA Stats API exposes both a ``WL`` (win/loss) flag and ``PTS`` for each
+    team. ``WL`` is the authoritative result, while ``PTS`` is occasionally wrong
+    in historical data. For example, game 0048300051 (1984-05-06, Suns vs. Jazz)
+    reports Utah with the higher score (113) yet flagged as the loss, and Phoenix
+    with fewer points (111) flagged as the win. Trusting ``PTS`` there flipped a
+    Phoenix win into a Utah win and made the 4-2 series render as a 3-3 tie.
+
+    We therefore prefer ``WL`` and only fall back to comparing scores when the
+    flag is missing (it can be null for some very old or in-progress games).
+    """
+    home_wl = home_team.get("WL")
+    away_wl = away_team.get("WL")
+
+    if home_wl == "W" or away_wl == "L":
+        return home_team
+    if away_wl == "W" or home_wl == "L":
+        return away_team
+
+    return home_team if home_score > away_score else away_team
+
+
 def normalize_playoff_games(df):
     normalized_games = []
 
@@ -346,7 +371,7 @@ def normalize_playoff_games(df):
         home_score = int(home_team["PTS"])
         away_score = int(away_team["PTS"])
 
-        winner_team = home_team if home_score > away_score else away_team
+        winner_team = determine_winner(home_team, away_team, home_score, away_score)
 
         normalized_games.append(
             {

--- a/server/tests/test_playoffs_conferences.py
+++ b/server/tests/test_playoffs_conferences.py
@@ -5,7 +5,6 @@ import pytest
 
 _CONFERENCES_JSON = (
     Path(__file__).resolve().parents[1]
-    / "server"
     / "constants"
     / "nbaConferences.json"
 )

--- a/server/tests/test_playoffs_winner.py
+++ b/server/tests/test_playoffs_winner.py
@@ -1,0 +1,78 @@
+"""Tests for playoff winner determination and series tallying.
+
+These tests are offline: they build synthetic game rows instead of hitting the
+NBA Stats API, so they are deterministic and fast.
+"""
+
+import pandas as pd
+
+from server.services import playoffs
+
+
+def _team_row(game_id, date, matchup, abbr, team_id, wl, pts):
+    return {
+        "GAME_ID": game_id,
+        "GAME_DATE": date,
+        "MATCHUP": matchup,
+        "TEAM_ID": team_id,
+        "TEAM_ABBREVIATION": abbr,
+        "TEAM_NAME": abbr,
+        "WL": wl,
+        "PTS": pts,
+    }
+
+
+def test_determine_winner_trusts_wl_over_pts():
+    """Regression for 1984-05-06 Suns/Jazz: PTS says Utah, WL says Phoenix."""
+    phx = {"WL": "W", "id": 1}  # 111 pts but flagged the win
+    uta = {"WL": "L", "id": 2}  # 113 pts but flagged the loss
+
+    winner = playoffs.determine_winner(phx, uta, home_score=111, away_score=113)
+    assert winner is phx
+
+
+def test_determine_winner_falls_back_to_score_when_wl_missing():
+    home = {"WL": None, "id": 1}
+    away = {"WL": None, "id": 2}
+
+    assert playoffs.determine_winner(home, away, 100, 98) is home
+    assert playoffs.determine_winner(home, away, 98, 100) is away
+
+
+def test_suns_jazz_1984_series_is_not_a_tie():
+    """The real 1984 West Semis were Phoenix 4-2 Utah.
+
+    Game 0048300051 (1984-05-06) has corrupt PTS in the source data (Utah 113 /
+    Phoenix 111) while the WL flags correctly show a Phoenix win. The series tally
+    must rely on WL so it does not render as a 3-3 tie.
+    """
+    PHX, UTA = 1610612756, 1610612762
+    # (game_id, date, phx_pts, uta_pts, phx_wl, uta_wl, phx_home)
+    games = [
+        ("0048300041", "1984-04-29", 95, 105, "L", "W", False),
+        ("0048300045", "1984-05-02", 102, 97, "W", "L", False),
+        ("0048300049", "1984-05-04", 106, 98, "W", "L", True),
+        # Corrupt PTS row: scores say Utah won, WL (correctly) says Phoenix won.
+        ("0048300051", "1984-05-06", 111, 113, "W", "L", True),
+        ("0048300056", "1984-05-08", 106, 118, "L", "W", False),
+        ("0048300059", "1984-05-10", 102, 82, "W", "L", True),
+    ]
+
+    rows = []
+    for gid, date, phx_pts, uta_pts, phx_wl, uta_wl, phx_home in games:
+        phx_matchup = "PHX vs. UTA" if phx_home else "PHX @ UTA"
+        uta_matchup = "UTA @ PHX" if phx_home else "UTA vs. PHX"
+        rows.append(_team_row(gid, date, phx_matchup, "PHX", PHX, phx_wl, phx_pts))
+        rows.append(_team_row(gid, date, uta_matchup, "UTA", UTA, uta_wl, uta_pts))
+
+    df = pd.DataFrame(rows)
+
+    normalized = playoffs.normalize_playoff_games(df)
+    series = playoffs.derive_playoff_series(normalized)
+
+    assert len(series) == 1
+    suns_jazz = series[0]
+
+    assert suns_jazz["wins"][PHX] == 4
+    assert suns_jazz["wins"][UTA] == 2
+    assert suns_jazz["winnerTeamId"] == PHX

--- a/server/tests/test_playoffs_winner.py
+++ b/server/tests/test_playoffs_winner.py
@@ -10,6 +10,7 @@ from server.services import playoffs
 
 
 def _team_row(game_id, date, matchup, abbr, team_id, wl, pts):
+    """Build a single LeagueGameFinder-style team row for a game."""
     return {
         "GAME_ID": game_id,
         "GAME_DATE": date,
@@ -32,6 +33,7 @@ def test_determine_winner_trusts_wl_over_pts():
 
 
 def test_determine_winner_falls_back_to_score_when_wl_missing():
+    """When the WL flag is absent, the higher score should win."""
     home = {"WL": None, "id": 1}
     away = {"WL": None, "id": 2}
 


### PR DESCRIPTION
## Problem

Two reported bugs share a single root cause:
- The **1984-05-06** game result was wrong.
- The **Suns-Jazz second-round series (1983-84)** rendered as a tie.

The playoff series winner was derived purely from each team's `PTS`. The NBA Stats API occasionally returns corrupt scores for historical games. For game `0048300051` (1984-05-06, Suns vs. Jazz) the API reports **Utah 113 flagged `L`** and **Phoenix 111 flagged `W`** — the points and the win/loss flag disagree. Trusting `PTS` flipped that game to Utah, turning the real **4-2 Phoenix** series into a **3-3 tie**.

I verified this is the only game in 1983-84 where score and `WL` disagree, and there are none in 2024-25.

## Fix

`determine_winner()` now prefers the authoritative `WL` flag and only falls back to comparing scores when `WL` is missing (it can be null for some very old or in-progress games). This corrects both the 1984-05-06 result and the Suns-Jazz series tally.

Note: the *displayed score* for that one game will still read 111-113 because the underlying API `PTS` is genuinely wrong (worth following up with the nba_api maintainers), but the series no longer shows a tie.

## Tests

- `server/tests/test_playoffs_winner.py`: asserts `WL` is preferred over `PTS`, the score fallback works, and the 1983-84 Suns-Jazz series resolves to 4-2 Phoenix (not a tie). Tests are offline (synthetic rows), so no flaky API calls.
- Also fixes a pre-existing wrong path in the conferences test fixture so the playoff suite can run.

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playoff winner determination to prioritize official win/loss indicators over raw score/point totals, with an automatic fallback to score comparison when win/loss data is unavailable.

* **Tests**
  * Added offline test coverage for winner determination and series tallying, including scenarios where historical point totals are intentionally inconsistent to ensure outcomes remain correct.

* **Chores**
  * Updated playoff conference test data path construction to use a more direct relative location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->