### PR TITLE
Stop serving stale current-season playoff data from cache (wrong Finals game count in prod)

### DIFF
--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -1,11 +1,15 @@
 import json
+import time
 from collections import defaultdict
+from datetime import datetime
 from pathlib import Path
 
 from fastapi import HTTPException
 from nba_api.stats.endpoints import leaguegamefinder
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
+
+from server.utils.season import get_nba_season
 
 _CONFERENCES_JSON = (
     Path(__file__).resolve().parent.parent / "constants" / "nbaConferences.json"
@@ -18,12 +22,31 @@ with open(_CONFERENCES_JSON) as _f:
 EAST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["east"])
 WEST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["west"])
 
+# season -> (fetched_at_monotonic, df)
 _df_cache: dict = {}
+
+# Past seasons are immutable and may be cached indefinitely. The current
+# (in-progress) season changes as new playoff games are played, so it is only
+# cached for a short window to avoid serving a stale game count in production.
+_CURRENT_SEASON_TTL_SECONDS = 300
+
+
+def get_current_season() -> str:
+    now = datetime.now()
+    return get_nba_season(now.year, now.month)
 
 
 def fetch_playoff_team_games_df(season: str):
-    if season in _df_cache:
-        return _df_cache[season]
+    cached = _df_cache.get(season)
+
+    if cached is not None:
+        fetched_at, df = cached
+        is_current_season = season == get_current_season()
+
+        # Past seasons never expire; the current season expires after the TTL so
+        # newly played games are picked up.
+        if not is_current_season or (time.monotonic() - fetched_at) < _CURRENT_SEASON_TTL_SECONDS:
+            return df
 
     try:
         games = leaguegamefinder.LeagueGameFinder(
@@ -35,7 +58,7 @@ def fetch_playoff_team_games_df(season: str):
         raise HTTPException(status_code=503, detail=f"NBA Stats API unavailable: {e}")
 
     df = games.get_data_frames()[0]
-    _df_cache[season] = df
+    _df_cache[season] = (time.monotonic(), df)
     return df
 
 

--- a/server/tests/test_playoffs_cache.py
+++ b/server/tests/test_playoffs_cache.py
@@ -1,0 +1,64 @@
+"""Tests for the playoff dataframe cache.
+
+The current (in-progress) season must not be cached indefinitely, otherwise a
+long-lived production server keeps serving a stale game count as new playoff
+games are played. Past seasons are immutable and may be cached forever.
+
+These tests are offline: the NBA Stats client and the clock are monkeypatched.
+"""
+
+import pandas as pd
+
+from server.services import playoffs
+
+
+def _patch_finder(monkeypatch):
+    calls = {"n": 0}
+
+    class _FakeFinder:
+        def __init__(self, *a, **k):
+            calls["n"] += 1
+
+        def get_data_frames(self):
+            return [pd.DataFrame()]
+
+    monkeypatch.setattr(playoffs.leaguegamefinder, "LeagueGameFinder", _FakeFinder)
+    monkeypatch.setattr(playoffs, "_df_cache", {})
+    return calls
+
+
+def _patch_clock(monkeypatch):
+    fake_time = {"t": 1000.0}
+    monkeypatch.setattr(playoffs.time, "monotonic", lambda: fake_time["t"])
+    return fake_time
+
+
+def test_current_season_cache_expires(monkeypatch):
+    monkeypatch.setattr(playoffs, "get_current_season", lambda: "2025-26")
+    calls = _patch_finder(monkeypatch)
+    fake_time = _patch_clock(monkeypatch)
+
+    playoffs.fetch_playoff_team_games_df("2025-26")
+    assert calls["n"] == 1
+
+    # Within TTL -> served from cache.
+    fake_time["t"] += playoffs._CURRENT_SEASON_TTL_SECONDS - 1
+    playoffs.fetch_playoff_team_games_df("2025-26")
+    assert calls["n"] == 1
+
+    # After TTL -> refetched so new games appear.
+    fake_time["t"] += 2
+    playoffs.fetch_playoff_team_games_df("2025-26")
+    assert calls["n"] == 2
+
+
+def test_past_season_cache_never_expires(monkeypatch):
+    monkeypatch.setattr(playoffs, "get_current_season", lambda: "2025-26")
+    calls = _patch_finder(monkeypatch)
+    fake_time = _patch_clock(monkeypatch)
+
+    playoffs.fetch_playoff_team_games_df("1983-84")
+    fake_time["t"] += 10 * playoffs._CURRENT_SEASON_TTL_SECONDS
+    playoffs.fetch_playoff_team_games_df("1983-84")
+
+    assert calls["n"] == 1

--- a/server/tests/test_playoffs_conferences.py
+++ b/server/tests/test_playoffs_conferences.py
@@ -5,7 +5,6 @@ import pytest
 
 _CONFERENCES_JSON = (
     Path(__file__).resolve().parents[1]
-    / "server"
     / "constants"
     / "nbaConferences.json"
 )


### PR DESCRIPTION
## Problem

In production the 2026 Finals series showed the wrong number of games, and it couldn't be reproduced in development.

The playoff dataframe cache (`_df_cache`) was keyed by season with **no expiry**. A long-lived production process caches the in-progress season on the first request and never refreshes it, so newly played Finals games never appear and the series is frozen at a stale game count. It was invisible in dev because `uvicorn --reload` restarts the worker and clears the cache on every code change.

## Fix

Cache entries now store a fetch timestamp `(fetched_at, df)`:
- **Past seasons** are immutable and still cached indefinitely.
- **The current season** expires after a short TTL (`_CURRENT_SEASON_TTL_SECONDS = 300`) so newly played games are picked up.

The current season is derived from the existing `get_nba_season` helper.

## Tests

- `server/tests/test_playoffs_cache.py`: monkeypatches the NBA client and the clock to assert the current season refetches after the TTL while past seasons never expire. Offline, no real API calls.
- Also fixes a pre-existing wrong path in the conferences test fixture so the playoff suite can run.

Generated with [Devin](https://cli.devin.ai/docs)