### PR TITLE
Correct corrupt playoff scores from boxscoresummaryv2 (Option 2 follow-up)

### DIFF
--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -1,11 +1,14 @@
 import json
 from collections import defaultdict
+from datetime import date
 from pathlib import Path
 
 from fastapi import HTTPException
-from nba_api.stats.endpoints import boxscoresummaryv2, leaguegamefinder
+from nba_api.stats.endpoints import LeagueGameLog, boxscoresummaryv2, leaguegamefinder
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
+
+from ..utils.season import get_nba_season
 
 _CONFERENCES_JSON = (
     Path(__file__).resolve().parent.parent / "constants" / "nbaConferences.json"
@@ -20,25 +23,49 @@ WEST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["west"])
 
 _df_cache: dict = {}
 
-# game_id -> {team_id: points}, cached so each corrupt game is only fetched once.
+# game_id -> {team_id: points}, cached so each defensive repair is only fetched once.
 _linescore_cache: dict = {}
 
 
-def fetch_playoff_team_games_df(season: str):
-    if season in _df_cache:
-        return _df_cache[season]
+def should_use_active_playoff_source(season: str, today: date | None = None) -> bool:
+    today = today or date.today()
+    current_season = get_nba_season(today.year, today.month)
+
+    return season == current_season and today.month in {4, 5, 6}
+
+
+def get_playoff_data_source(season: str, today: date | None = None) -> str:
+    if should_use_active_playoff_source(season, today):
+        return "league_game_finder"
+
+    return "league_game_log"
+
+
+def fetch_playoff_team_games_df(season: str, today: date | None = None):
+    source = get_playoff_data_source(season, today)
+    cache_key = (season, source)
+
+    if cache_key in _df_cache:
+        return _df_cache[cache_key]
 
     try:
-        games = leaguegamefinder.LeagueGameFinder(
-            season_nullable=season,
-            season_type_nullable="Playoffs",
-            league_id_nullable="00",
-        )
+        if source == "league_game_finder":
+            games = leaguegamefinder.LeagueGameFinder(
+                season_nullable=season,
+                season_type_nullable="Playoffs",
+                league_id_nullable="00",
+            )
+        else:
+            games = LeagueGameLog(
+                season=season,
+                season_type_all_star="Playoffs",
+                league_id="00",
+            )
     except (ReadTimeout, RequestsConnectionError) as e:
         raise HTTPException(status_code=503, detail=f"NBA Stats API unavailable: {e}")
 
     df = games.get_data_frames()[0]
-    _df_cache[season] = df
+    _df_cache[cache_key] = df
     return df
 
 
@@ -333,14 +360,10 @@ def determine_winner(home_team, away_team, home_score, away_score):
     Determine the winning team for a game.
 
     The NBA Stats API exposes both a ``WL`` (win/loss) flag and ``PTS`` for each
-    team. ``WL`` is the authoritative result, while ``PTS`` is occasionally wrong
-    in historical data. For example, game 0048300051 (1984-05-06, Suns vs. Jazz)
-    reports Utah with the higher score (113) yet flagged as the loss, and Phoenix
-    with fewer points (111) flagged as the win. Trusting ``PTS`` there flipped a
-    Phoenix win into a Utah win and made the 4-2 series render as a 3-3 tie.
-
-    We therefore prefer ``WL`` and only fall back to comparing scores when the
-    flag is missing (it can be null for some very old or in-progress games).
+    team. ``WL`` is the authoritative result, while score rows can occasionally
+    be inconsistent depending on the NBA Stats source. We therefore prefer
+    ``WL`` and only fall back to comparing scores when the flag is missing (it
+    can be null for some very old or in-progress games).
     """
     home_wl = home_team.get("WL")
     away_wl = away_team.get("WL")
@@ -409,10 +432,10 @@ def game_scores_disagree_with_winner(game):
     """
     True when a game's displayed scores contradict its (WL-derived) winner.
 
-    LeagueGameFinder occasionally returns a corrupt PTS value. Once the winner is
-    taken from the WL flag, such a game has the winner showing fewer points than
-    the loser, e.g. game 0048300051 lists Phoenix as the winner with 111 but Utah
-    with 113. That mismatch is the signal to repair the score.
+    LeagueGameLog is the normal historical/completed source and should already
+    have correct final scores. This defensive check protects the active playoff
+    window source, or any future source inconsistency, where a score row may
+    contradict the WL flag.
     """
     winner_id = game.get("winnerTeamId")
     home = game["homeTeam"]
@@ -431,9 +454,9 @@ def fetch_corrected_team_scores(game_id):
     Fetch authoritative per-team final scores from boxscoresummaryv2.
 
     Returns ``{team_id: points}`` or ``None`` when the data is unavailable. Used
-    only to repair the rare games whose LeagueGameFinder PTS disagrees with WL;
-    boxscoresummaryv2 carries the correct linescore (verified against
-    Basketball-Reference for the 1984 Suns/Jazz game).
+    only as a temporary defensive repair when the selected source's PTS values
+    disagree with WL. Historical/completed playoff data normally comes from
+    LeagueGameLog and should not need this correction.
     """
     if game_id in _linescore_cache:
         return _linescore_cache[game_id]
@@ -465,8 +488,8 @@ def correct_game_scores(games):
 
     Mutates and returns ``games``. The WL-derived ``winnerTeamId`` is left intact;
     only the points are overwritten with the real linescore. Games whose scores
-    already agree with the winner are untouched, so in a normal season this makes
-    zero extra API calls.
+    already agree with the winner are untouched, so the normal LeagueGameLog path
+    makes zero extra API calls.
     """
     for game in games:
         if not game_scores_disagree_with_winner(game):

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -325,6 +325,31 @@ def apply_rounds_to_games(games):
     )
 
 
+def determine_winner(home_team, away_team, home_score, away_score):
+    """
+    Determine the winning team for a game.
+
+    The NBA Stats API exposes both a ``WL`` (win/loss) flag and ``PTS`` for each
+    team. ``WL`` is the authoritative result, while ``PTS`` is occasionally wrong
+    in historical data. For example, game 0048300051 (1984-05-06, Suns vs. Jazz)
+    reports Utah with the higher score (113) yet flagged as the loss, and Phoenix
+    with fewer points (111) flagged as the win. Trusting ``PTS`` there flipped a
+    Phoenix win into a Utah win and made the 4-2 series render as a 3-3 tie.
+
+    We therefore prefer ``WL`` and only fall back to comparing scores when the
+    flag is missing (it can be null for some very old or in-progress games).
+    """
+    home_wl = home_team.get("WL")
+    away_wl = away_team.get("WL")
+
+    if home_wl == "W" or away_wl == "L":
+        return home_team
+    if away_wl == "W" or home_wl == "L":
+        return away_team
+
+    return home_team if home_score > away_score else away_team
+
+
 def normalize_playoff_games(df):
     normalized_games = []
 
@@ -346,7 +371,7 @@ def normalize_playoff_games(df):
         home_score = int(home_team["PTS"])
         away_score = int(away_team["PTS"])
 
-        winner_team = home_team if home_score > away_score else away_team
+        winner_team = determine_winner(home_team, away_team, home_score, away_score)
 
         normalized_games.append(
             {

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -63,10 +63,13 @@ def fetch_playoff_team_games_df(season: str, today: date | None = None):
                 season_type_all_star="Playoffs",
                 league_id="00",
             )
+        df = games.get_data_frames()[0]
     except (ReadTimeout, RequestsConnectionError) as e:
-        raise HTTPException(status_code=503, detail=f"NBA Stats API unavailable: {e}")
+        raise HTTPException(
+            status_code=503,
+            detail=f"NBA Stats API unavailable: {e}",
+        ) from e
 
-    df = games.get_data_frames()[0]
     _df_cache[cache_key] = df
     return df
 

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from fastapi import HTTPException
-from nba_api.stats.endpoints import leaguegamefinder
+from nba_api.stats.endpoints import boxscoresummaryv2, leaguegamefinder
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
 
@@ -19,6 +19,9 @@ EAST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["east"])
 WEST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["west"])
 
 _df_cache: dict = {}
+
+# game_id -> {team_id: points}, cached so each corrupt game is only fetched once.
+_linescore_cache: dict = {}
 
 
 def fetch_playoff_team_games_df(season: str):
@@ -402,6 +405,85 @@ def normalize_playoff_games(df):
     )
 
 
+def game_scores_disagree_with_winner(game):
+    """
+    True when a game's displayed scores contradict its (WL-derived) winner.
+
+    LeagueGameFinder occasionally returns a corrupt PTS value. Once the winner is
+    taken from the WL flag, such a game has the winner showing fewer points than
+    the loser, e.g. game 0048300051 lists Phoenix as the winner with 111 but Utah
+    with 113. That mismatch is the signal to repair the score.
+    """
+    winner_id = game.get("winnerTeamId")
+    home = game["homeTeam"]
+    away = game["awayTeam"]
+
+    if winner_id == home["id"]:
+        return home["score"] <= away["score"]
+    if winner_id == away["id"]:
+        return away["score"] <= home["score"]
+
+    return False
+
+
+def fetch_corrected_team_scores(game_id):
+    """
+    Fetch authoritative per-team final scores from boxscoresummaryv2.
+
+    Returns ``{team_id: points}`` or ``None`` when the data is unavailable. Used
+    only to repair the rare games whose LeagueGameFinder PTS disagrees with WL;
+    boxscoresummaryv2 carries the correct linescore (verified against
+    Basketball-Reference for the 1984 Suns/Jazz game).
+    """
+    if game_id in _linescore_cache:
+        return _linescore_cache[game_id]
+
+    try:
+        line_score = boxscoresummaryv2.BoxScoreSummaryV2(
+            game_id=game_id
+        ).line_score.get_data_frame()
+    except (ReadTimeout, RequestsConnectionError):
+        return None
+
+    scores = {}
+    for _, row in line_score.iterrows():
+        try:
+            scores[int(row["TEAM_ID"])] = int(row["PTS"])
+        except (TypeError, ValueError):
+            continue
+
+    if not scores:
+        return None
+
+    _linescore_cache[game_id] = scores
+    return scores
+
+
+def correct_game_scores(games):
+    """
+    Repair displayed scores for games whose PTS disagrees with the WL winner.
+
+    Mutates and returns ``games``. The WL-derived ``winnerTeamId`` is left intact;
+    only the points are overwritten with the real linescore. Games whose scores
+    already agree with the winner are untouched, so in a normal season this makes
+    zero extra API calls.
+    """
+    for game in games:
+        if not game_scores_disagree_with_winner(game):
+            continue
+
+        corrected = fetch_corrected_team_scores(game["gameId"])
+        if not corrected:
+            continue
+
+        for side in ("homeTeam", "awayTeam"):
+            team = game[side]
+            if team["id"] in corrected:
+                team["score"] = corrected[team["id"]]
+
+    return games
+
+
 def get_series_key(game):
     team_ids = sorted(
         [
@@ -614,6 +696,7 @@ def derive_playoff_series(games):
 def get_normalized_playoff_games(season: str):
     df = fetch_playoff_team_games_df(season)
     games = normalize_playoff_games(df)
+    games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
 
     return {
@@ -627,6 +710,7 @@ def get_normalized_playoff_games(season: str):
 def get_playoff_series(season: str):
     df = fetch_playoff_team_games_df(season)
     games = normalize_playoff_games(df)
+    games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
     playoff_series = derive_playoff_series(games)
 
@@ -642,6 +726,7 @@ def get_playoff_series(season: str):
 def get_playoff_games_and_series(season: str):
     df = fetch_playoff_team_games_df(season)
     games = normalize_playoff_games(df)
+    games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
     playoff_series = derive_playoff_series(games)
 

--- a/server/tests/test_playoffs_conferences.py
+++ b/server/tests/test_playoffs_conferences.py
@@ -5,7 +5,6 @@ import pytest
 
 _CONFERENCES_JSON = (
     Path(__file__).resolve().parents[1]
-    / "server"
     / "constants"
     / "nbaConferences.json"
 )

--- a/server/tests/test_playoffs_data_source.py
+++ b/server/tests/test_playoffs_data_source.py
@@ -1,0 +1,122 @@
+from datetime import date
+
+import pandas as pd
+
+from server.services import playoffs
+
+
+def test_historical_season_uses_league_game_log():
+    assert (
+        playoffs.get_playoff_data_source("1983-84", date(2026, 6, 16))
+        == "league_game_log"
+    )
+
+
+def test_current_season_during_playoff_window_uses_league_game_finder():
+    assert (
+        playoffs.get_playoff_data_source("2025-26", date(2026, 5, 15))
+        == "league_game_finder"
+    )
+
+
+def test_current_season_outside_playoff_window_uses_league_game_log():
+    assert (
+        playoffs.get_playoff_data_source("2025-26", date(2026, 7, 1))
+        == "league_game_log"
+    )
+
+
+def test_previous_season_during_playoff_window_uses_league_game_log():
+    assert (
+        playoffs.get_playoff_data_source("2024-25", date(2026, 5, 15))
+        == "league_game_log"
+    )
+
+
+def test_fetch_uses_league_game_log_for_completed_season(monkeypatch):
+    calls = []
+    expected = pd.DataFrame([{"GAME_ID": "0048300047"}])
+    monkeypatch.setattr(playoffs, "_df_cache", {})
+
+    class FakeLeagueGameLog:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+        def get_data_frames(self):
+            return [expected]
+
+    monkeypatch.setattr(playoffs, "LeagueGameLog", FakeLeagueGameLog)
+
+    df = playoffs.fetch_playoff_team_games_df("1983-84", date(2026, 6, 16))
+
+    assert df is expected
+    assert calls == [
+        {
+            "season": "1983-84",
+            "season_type_all_star": "Playoffs",
+            "league_id": "00",
+        }
+    ]
+
+
+def test_fetch_uses_league_game_finder_for_current_playoff_window(monkeypatch):
+    calls = []
+    expected = pd.DataFrame([{"GAME_ID": "0042500001"}])
+    monkeypatch.setattr(playoffs, "_df_cache", {})
+
+    class FakeLeagueGameFinder:
+        def __init__(self, **kwargs):
+            calls.append(kwargs)
+
+        def get_data_frames(self):
+            return [expected]
+
+    monkeypatch.setattr(
+        playoffs.leaguegamefinder,
+        "LeagueGameFinder",
+        FakeLeagueGameFinder,
+    )
+
+    df = playoffs.fetch_playoff_team_games_df("2025-26", date(2026, 5, 15))
+
+    assert df is expected
+    assert calls == [
+        {
+            "season_nullable": "2025-26",
+            "season_type_nullable": "Playoffs",
+            "league_id_nullable": "00",
+        }
+    ]
+
+
+def test_fetch_cache_is_source_aware(monkeypatch):
+    log_df = pd.DataFrame([{"GAME_ID": "log"}])
+    finder_df = pd.DataFrame([{"GAME_ID": "finder"}])
+    monkeypatch.setattr(playoffs, "_df_cache", {})
+
+    class FakeLeagueGameLog:
+        def __init__(self, **kwargs):
+            pass
+
+        def get_data_frames(self):
+            return [log_df]
+
+    class FakeLeagueGameFinder:
+        def __init__(self, **kwargs):
+            pass
+
+        def get_data_frames(self):
+            return [finder_df]
+
+    monkeypatch.setattr(playoffs, "LeagueGameLog", FakeLeagueGameLog)
+    monkeypatch.setattr(
+        playoffs.leaguegamefinder,
+        "LeagueGameFinder",
+        FakeLeagueGameFinder,
+    )
+
+    active = playoffs.fetch_playoff_team_games_df("2025-26", date(2026, 5, 15))
+    completed = playoffs.fetch_playoff_team_games_df("2025-26", date(2026, 7, 1))
+
+    assert active is finder_df
+    assert completed is log_df

--- a/server/tests/test_playoffs_data_source.py
+++ b/server/tests/test_playoffs_data_source.py
@@ -1,6 +1,9 @@
 from datetime import date
 
 import pandas as pd
+import pytest
+from fastapi import HTTPException
+from requests.exceptions import ReadTimeout
 
 from server.services import playoffs
 
@@ -87,6 +90,26 @@ def test_fetch_uses_league_game_finder_for_current_playoff_window(monkeypatch):
             "league_id_nullable": "00",
         }
     ]
+
+
+def test_fetch_maps_data_frame_timeout_to_service_unavailable(monkeypatch):
+    monkeypatch.setattr(playoffs, "_df_cache", {})
+
+    class FakeLeagueGameLog:
+        def __init__(self, **kwargs):
+            pass
+
+        def get_data_frames(self):
+            raise ReadTimeout("boom")
+
+    monkeypatch.setattr(playoffs, "LeagueGameLog", FakeLeagueGameLog)
+
+    with pytest.raises(HTTPException) as exc:
+        playoffs.fetch_playoff_team_games_df("1983-84", date(2026, 6, 16))
+
+    assert exc.value.status_code == 503
+    assert "NBA Stats API unavailable" in exc.value.detail
+    assert isinstance(exc.value.__cause__, ReadTimeout)
 
 
 def test_fetch_cache_is_source_aware(monkeypatch):

--- a/server/tests/test_playoffs_score_correction.py
+++ b/server/tests/test_playoffs_score_correction.py
@@ -1,4 +1,4 @@
-"""Tests for repairing playoff scores when LeagueGameFinder PTS is corrupt.
+"""Tests for defensive playoff score repair.
 
 These tests are offline: the boxscoresummaryv2 client is monkeypatched, so no
 real API calls are made.
@@ -22,7 +22,7 @@ def _game(winner_id, home_id, home_score, away_id, away_score, game_id="00483000
 
 
 def test_disagreement_detected_when_winner_has_fewer_points():
-    """The corrupt 1984 game: Phoenix wins but shows fewer points than Utah."""
+    """A source inconsistency can show the winner with fewer points."""
     game = _game(PHX, home_id=PHX, home_score=111, away_id=UTA, away_score=113)
     assert playoffs.game_scores_disagree_with_winner(game) is True
 
@@ -55,7 +55,7 @@ def test_correct_game_scores_repairs_only_mismatched_game(monkeypatch):
 
     # Only the mismatched game triggered a fetch.
     assert calls == ["0048300051"]
-    # Utah's corrupt 113 is repaired to the real 110; winner is untouched.
+    # The bad source score is repaired to the real line score; winner is untouched.
     assert bad["awayTeam"]["score"] == 110
     assert bad["homeTeam"]["score"] == 111
     assert bad["winnerTeamId"] == PHX

--- a/server/tests/test_playoffs_score_correction.py
+++ b/server/tests/test_playoffs_score_correction.py
@@ -1,0 +1,104 @@
+"""Tests for repairing playoff scores when LeagueGameFinder PTS is corrupt.
+
+These tests are offline: the boxscoresummaryv2 client is monkeypatched, so no
+real API calls are made.
+"""
+
+import pandas as pd
+
+from server.services import playoffs
+
+PHX, UTA = 1610612756, 1610612762
+
+
+def _game(winner_id, home_id, home_score, away_id, away_score, game_id="0048300051"):
+    """Build a normalized game dict with the given winner and scores."""
+    return {
+        "gameId": game_id,
+        "winnerTeamId": winner_id,
+        "homeTeam": {"id": home_id, "score": home_score},
+        "awayTeam": {"id": away_id, "score": away_score},
+    }
+
+
+def test_disagreement_detected_when_winner_has_fewer_points():
+    """The corrupt 1984 game: Phoenix wins but shows fewer points than Utah."""
+    game = _game(PHX, home_id=PHX, home_score=111, away_id=UTA, away_score=113)
+    assert playoffs.game_scores_disagree_with_winner(game) is True
+
+
+def test_no_disagreement_when_scores_match_winner():
+    game = _game(PHX, home_id=PHX, home_score=111, away_id=UTA, away_score=110)
+    assert playoffs.game_scores_disagree_with_winner(game) is False
+
+
+def test_no_disagreement_when_winner_unknown():
+    game = _game(None, home_id=PHX, home_score=111, away_id=UTA, away_score=113)
+    assert playoffs.game_scores_disagree_with_winner(game) is False
+
+
+def test_correct_game_scores_repairs_only_mismatched_game(monkeypatch):
+    calls = []
+
+    def fake_fetch(game_id):
+        calls.append(game_id)
+        return {PHX: 111, UTA: 110}
+
+    monkeypatch.setattr(playoffs, "fetch_corrected_team_scores", fake_fetch)
+
+    bad = _game(PHX, home_id=PHX, home_score=111, away_id=UTA, away_score=113,
+                game_id="0048300051")
+    good = _game(PHX, home_id=PHX, home_score=120, away_id=UTA, away_score=100,
+                 game_id="0048300049")
+
+    playoffs.correct_game_scores([bad, good])
+
+    # Only the mismatched game triggered a fetch.
+    assert calls == ["0048300051"]
+    # Utah's corrupt 113 is repaired to the real 110; winner is untouched.
+    assert bad["awayTeam"]["score"] == 110
+    assert bad["homeTeam"]["score"] == 111
+    assert bad["winnerTeamId"] == PHX
+    # The consistent game is left exactly as-is.
+    assert good["homeTeam"]["score"] == 120
+    assert good["awayTeam"]["score"] == 100
+
+
+def test_correct_game_scores_keeps_original_when_fetch_fails(monkeypatch):
+    monkeypatch.setattr(playoffs, "fetch_corrected_team_scores", lambda gid: None)
+
+    bad = _game(PHX, home_id=PHX, home_score=111, away_id=UTA, away_score=113)
+    playoffs.correct_game_scores([bad])
+
+    assert bad["homeTeam"]["score"] == 111
+    assert bad["awayTeam"]["score"] == 113
+
+
+def test_fetch_corrected_team_scores_parses_and_caches(monkeypatch):
+    monkeypatch.setattr(playoffs, "_linescore_cache", {})
+
+    calls = {"n": 0}
+
+    class _FakeResult:
+        def get_data_frame(self):
+            return pd.DataFrame(
+                [
+                    {"TEAM_ID": PHX, "PTS": 111},
+                    {"TEAM_ID": UTA, "PTS": 110},
+                ]
+            )
+
+    class _FakeSummary:
+        def __init__(self, *a, **k):
+            calls["n"] += 1
+            self.line_score = _FakeResult()
+
+    monkeypatch.setattr(playoffs.boxscoresummaryv2, "BoxScoreSummaryV2", _FakeSummary)
+
+    first = playoffs.fetch_corrected_team_scores("0048300051")
+    assert first == {PHX: 111, UTA: 110}
+
+    # Second call is served from cache (no new API construction).
+    second = playoffs.fetch_corrected_team_scores("0048300051")
+    assert second == {PHX: 111, UTA: 110}
+    assert calls["n"] == 1

--- a/server/tests/test_playoffs_winner.py
+++ b/server/tests/test_playoffs_winner.py
@@ -1,0 +1,78 @@
+"""Tests for playoff winner determination and series tallying.
+
+These tests are offline: they build synthetic game rows instead of hitting the
+NBA Stats API, so they are deterministic and fast.
+"""
+
+import pandas as pd
+
+from server.services import playoffs
+
+
+def _team_row(game_id, date, matchup, abbr, team_id, wl, pts):
+    return {
+        "GAME_ID": game_id,
+        "GAME_DATE": date,
+        "MATCHUP": matchup,
+        "TEAM_ID": team_id,
+        "TEAM_ABBREVIATION": abbr,
+        "TEAM_NAME": abbr,
+        "WL": wl,
+        "PTS": pts,
+    }
+
+
+def test_determine_winner_trusts_wl_over_pts():
+    """Regression for 1984-05-06 Suns/Jazz: PTS says Utah, WL says Phoenix."""
+    phx = {"WL": "W", "id": 1}  # 111 pts but flagged the win
+    uta = {"WL": "L", "id": 2}  # 113 pts but flagged the loss
+
+    winner = playoffs.determine_winner(phx, uta, home_score=111, away_score=113)
+    assert winner is phx
+
+
+def test_determine_winner_falls_back_to_score_when_wl_missing():
+    home = {"WL": None, "id": 1}
+    away = {"WL": None, "id": 2}
+
+    assert playoffs.determine_winner(home, away, 100, 98) is home
+    assert playoffs.determine_winner(home, away, 98, 100) is away
+
+
+def test_suns_jazz_1984_series_is_not_a_tie():
+    """The real 1984 West Semis were Phoenix 4-2 Utah.
+
+    Game 0048300051 (1984-05-06) has corrupt PTS in the source data (Utah 113 /
+    Phoenix 111) while the WL flags correctly show a Phoenix win. The series tally
+    must rely on WL so it does not render as a 3-3 tie.
+    """
+    PHX, UTA = 1610612756, 1610612762
+    # (game_id, date, phx_pts, uta_pts, phx_wl, uta_wl, phx_home)
+    games = [
+        ("0048300041", "1984-04-29", 95, 105, "L", "W", False),
+        ("0048300045", "1984-05-02", 102, 97, "W", "L", False),
+        ("0048300049", "1984-05-04", 106, 98, "W", "L", True),
+        # Corrupt PTS row: scores say Utah won, WL (correctly) says Phoenix won.
+        ("0048300051", "1984-05-06", 111, 113, "W", "L", True),
+        ("0048300056", "1984-05-08", 106, 118, "L", "W", False),
+        ("0048300059", "1984-05-10", 102, 82, "W", "L", True),
+    ]
+
+    rows = []
+    for gid, date, phx_pts, uta_pts, phx_wl, uta_wl, phx_home in games:
+        phx_matchup = "PHX vs. UTA" if phx_home else "PHX @ UTA"
+        uta_matchup = "UTA @ PHX" if phx_home else "UTA vs. PHX"
+        rows.append(_team_row(gid, date, phx_matchup, "PHX", PHX, phx_wl, phx_pts))
+        rows.append(_team_row(gid, date, uta_matchup, "UTA", UTA, uta_wl, uta_pts))
+
+    df = pd.DataFrame(rows)
+
+    normalized = playoffs.normalize_playoff_games(df)
+    series = playoffs.derive_playoff_series(normalized)
+
+    assert len(series) == 1
+    suns_jazz = series[0]
+
+    assert suns_jazz["wins"][PHX] == 4
+    assert suns_jazz["wins"][UTA] == 2
+    assert suns_jazz["winnerTeamId"] == PHX

--- a/server/tests/test_playoffs_winner.py
+++ b/server/tests/test_playoffs_winner.py
@@ -10,6 +10,7 @@ from server.services import playoffs
 
 
 def _team_row(game_id, date, matchup, abbr, team_id, wl, pts):
+    """Build a single LeagueGameFinder-style team row for a game."""
     return {
         "GAME_ID": game_id,
         "GAME_DATE": date,
@@ -32,6 +33,7 @@ def test_determine_winner_trusts_wl_over_pts():
 
 
 def test_determine_winner_falls_back_to_score_when_wl_missing():
+    """When the WL flag is absent, the higher score should win."""
     home = {"WL": None, "id": 1}
     away = {"WL": None, "id": 2}
 

--- a/server/tests/test_playoffs_winner.py
+++ b/server/tests/test_playoffs_winner.py
@@ -10,7 +10,7 @@ from server.services import playoffs
 
 
 def _team_row(game_id, date, matchup, abbr, team_id, wl, pts):
-    """Build a single LeagueGameFinder-style team row for a game."""
+    """Build a single NBA game-log-style team row for a game."""
     return {
         "GAME_ID": game_id,
         "GAME_DATE": date,
@@ -41,20 +41,15 @@ def test_determine_winner_falls_back_to_score_when_wl_missing():
     assert playoffs.determine_winner(home, away, 98, 100) is away
 
 
-def test_suns_jazz_1984_series_is_not_a_tie():
-    """The real 1984 West Semis were Phoenix 4-2 Utah.
-
-    Game 0048300051 (1984-05-06) has corrupt PTS in the source data (Utah 113 /
-    Phoenix 111) while the WL flags correctly show a Phoenix win. The series tally
-    must rely on WL so it does not render as a 3-3 tie.
-    """
+def test_series_tally_uses_wl_not_pts_when_source_score_contradicts_winner():
+    """WL remains the source of truth if a source score contradicts the winner."""
     PHX, UTA = 1610612756, 1610612762
     # (game_id, date, phx_pts, uta_pts, phx_wl, uta_wl, phx_home)
     games = [
         ("0048300041", "1984-04-29", 95, 105, "L", "W", False),
         ("0048300045", "1984-05-02", 102, 97, "W", "L", False),
         ("0048300049", "1984-05-04", 106, 98, "W", "L", True),
-        # Corrupt PTS row: scores say Utah won, WL (correctly) says Phoenix won.
+        # Synthetic source inconsistency: scores say Utah won, WL says Phoenix won.
         ("0048300051", "1984-05-06", 111, 113, "W", "L", True),
         ("0048300056", "1984-05-08", 106, 118, "L", "W", False),
         ("0048300059", "1984-05-10", 102, 82, "W", "L", True),
@@ -78,3 +73,51 @@ def test_suns_jazz_1984_series_is_not_a_tie():
     assert suns_jazz["wins"][PHX] == 4
     assert suns_jazz["wins"][UTA] == 2
     assert suns_jazz["winnerTeamId"] == PHX
+
+
+def test_known_historical_scores_normalize_without_defensive_repair(monkeypatch):
+    """LeagueGameLog-style completed playoff rows already carry corrected scores."""
+    rows = [
+        _team_row("0048300047", "1984-05-04", "NYK vs. BOS", "NYK", 1610612752, "W", 100),
+        _team_row("0048300047", "1984-05-04", "BOS @ NYK", "BOS", 1610612738, "L", 92),
+        _team_row("0048300049", "1984-05-04", "PHX vs. UTH", "PHX", 1610612756, "W", 106),
+        _team_row("0048300049", "1984-05-04", "UTH @ PHX", "UTH", 1610612762, "L", 94),
+        _team_row("0048300051", "1984-05-06", "PHX vs. UTH", "PHX", 1610612756, "W", 111),
+        _team_row("0048300051", "1984-05-06", "UTH @ PHX", "UTH", 1610612762, "L", 110),
+        _team_row("0048300052", "1984-05-06", "NYK vs. BOS", "NYK", 1610612752, "W", 118),
+        _team_row("0048300052", "1984-05-06", "BOS @ NYK", "BOS", 1610612738, "L", 113),
+        _team_row("0048300053", "1984-05-06", "DAL vs. LAL", "DAL", 1610612742, "L", 115),
+        _team_row("0048300053", "1984-05-06", "LAL @ DAL", "LAL", 1610612747, "W", 122),
+        _team_row("0048500304", "1986-05-18", "MIL vs. BOS", "MIL", 1610612749, "L", 98),
+        _team_row("0048500304", "1986-05-18", "BOS @ MIL", "BOS", 1610612738, "W", 111),
+        _team_row("0048600054", "1987-05-16", "LAL vs. SEA", "LAL", 1610612747, "W", 92),
+        _team_row("0048600054", "1987-05-16", "SEA @ LAL", "SEA", 1610612760, "L", 87),
+    ]
+
+    fetch_calls = []
+    monkeypatch.setattr(
+        playoffs,
+        "fetch_corrected_team_scores",
+        lambda game_id: fetch_calls.append(game_id),
+    )
+
+    normalized = playoffs.normalize_playoff_games(pd.DataFrame(rows))
+    corrected = playoffs.correct_game_scores(normalized)
+
+    by_game = {game["gameId"]: game for game in corrected}
+
+    assert by_game["0048300047"]["awayTeam"]["score"] == 92
+    assert by_game["0048300047"]["homeTeam"]["score"] == 100
+    assert by_game["0048300049"]["awayTeam"]["score"] == 94
+    assert by_game["0048300049"]["homeTeam"]["score"] == 106
+    assert by_game["0048300051"]["awayTeam"]["score"] == 110
+    assert by_game["0048300051"]["homeTeam"]["score"] == 111
+    assert by_game["0048300052"]["awayTeam"]["score"] == 113
+    assert by_game["0048300052"]["homeTeam"]["score"] == 118
+    assert by_game["0048300053"]["awayTeam"]["score"] == 122
+    assert by_game["0048300053"]["homeTeam"]["score"] == 115
+    assert by_game["0048500304"]["awayTeam"]["score"] == 111
+    assert by_game["0048500304"]["homeTeam"]["score"] == 98
+    assert by_game["0048600054"]["awayTeam"]["score"] == 87
+    assert by_game["0048600054"]["homeTeam"]["score"] == 92
+    assert fetch_calls == []

--- a/src/components/MobileBracket.tsx
+++ b/src/components/MobileBracket.tsx
@@ -50,7 +50,7 @@ function RoundSection({
     return () => {
       if (timerRef.current) clearTimeout(timerRef.current);
     };
-  }, [isRevealed]);
+  }, [isRevealed, canScrollForMore]);
 
   return (
     <div>

--- a/src/routes/playoffs/SeriesDetail.tsx
+++ b/src/routes/playoffs/SeriesDetail.tsx
@@ -9,19 +9,8 @@ import { yearToSeason, findSeriesBySlug } from '@/utils/seriesSlug';
 
 function SeriesDetail() {
   const { year, seriesSlug } = useParams<{ year: string; seriesSlug: string }>();
-
-  if (!year || !/^\d{4}$/.test(year)) {
-    return (
-      <div className="p-4">
-        <p className="dark:text-slate-50">Invalid season year.</p>
-        <Link to="/playoffs" className="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300">
-          Back to Playoffs
-        </Link>
-      </div>
-    );
-  }
-
-  const season = yearToSeason(year);
+  const isValidYear = !!year && /^\d{4}$/.test(year);
+  const season = isValidYear ? yearToSeason(year) : null;
   const [searchParams, setSearchParams] = useSearchParams();
   const isRevealed = searchParams.get('revealed') === 'true';
   const setIsRevealed = (value: boolean) => {
@@ -32,8 +21,18 @@ function SeriesDetail() {
       return next;
     }, { replace: true });
   };
-
   const { data, isLoading, error } = usePlayoffData(season);
+
+  if (!isValidYear) {
+    return (
+      <div className="p-4">
+        <p className="dark:text-slate-50">Invalid season year.</p>
+        <Link to="/playoffs" className="text-blue-500 hover:text-blue-600 dark:text-blue-400 dark:hover:text-blue-300">
+          Back to Playoffs
+        </Link>
+      </div>
+    );
+  }
 
   if (isLoading) return <p className="p-4 dark:text-slate-50">Loading...</p>;
   if (error) return <p className="p-4 dark:text-slate-50">Error: {String(error)}</p>;


### PR DESCRIPTION
Follow-up to #162 implementing the boxscore-based score correction discussed there.

> **Stacked on #162.** This branch is built on top of `fix/playoff-winner-uses-wl`, so until #162 merges its commits also show in this diff. Merge #162 first; this diff then reduces to just the score-correction commit.

## Why

#162 fixes the *winner* by trusting the `WL` flag, but `LeagueGameFinder` can still return a corrupt *score*. For game `0048300051` (1984-05-06) it lists Utah 113 even though Phoenix won 111. I confirmed `boxscoresummaryv2` carries the correct linescore — **PHX 111 / UTH 110 (OT)** — matching [Basketball-Reference](https://www.basketball-reference.com/playoffs/1984-nba-western-conference-semifinals-suns-vs-jazz.html).

## Approach

- `game_scores_disagree_with_winner()` flags games where the `WL`-derived winner shows fewer points than the loser — the signal that `PTS` is corrupt.
- Only for those games, `fetch_corrected_team_scores()` pulls the real linescore from `boxscoresummaryv2` and the points are overwritten. `winnerTeamId` (from `WL`) is left untouched.
- Results are cached per game (`_linescore_cache`), and consistent games trigger **zero** extra API calls — so no overhead in a normal season and the rate-limit surface is limited to the rare corrupt game.
- The correction runs in the top-level getters, not in `normalize_playoff_games`, so normalization stays network-free and unit-testable.

## Result

End-to-end on 1983-84, game `0048300051` now reports **PHX 111 / UTH 110**, winner Phoenix, and the Suns-Jazz series reads **4-2 Phoenix** (no tie, and the displayed score is now correct).

## Tests

`server/tests/test_playoffs_score_correction.py` (offline, boxscore client monkeypatched): mismatch detection, that only mismatched games are fetched/repaired, winner is preserved, original scores are kept if the fetch fails, and linescore parsing + caching.

Generated with [Devin](https://cli.devin.ai/docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected playoff game scores that contradicted official results
  * Fixed mobile "scroll for more" hint behavior during interactions
  * Improved invalid season year error handling

* **Improvements**
  * Enhanced playoff game winner determination using authoritative data sources
  * Optimized playoff data selection based on season and timing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->