### PR TITLE
Support playoff formats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,26 +172,19 @@ For full workflow details: `bd prime`
 
 ## Landing the Plane (Session Completion)
 
-**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+When ending a work session, complete the applicable local handoff steps below. Do not push to remote unless the user explicitly asks for it.
 
-**MANDATORY WORKFLOW:**
+**Recommended workflow:**
 
 1. **File issues for remaining work** - Create issues for anything that needs follow-up
 2. **Run quality gates** (if code changed) - Tests, linters, builds
 3. **Update issue status** - Close finished work, update in-progress items
-4. **PUSH TO REMOTE** - This is MANDATORY:
-   ```bash
-   git pull --rebase
-   bd sync
-   git push
-   git status  # MUST show "up to date with origin"
-   ```
-5. **Clean up** - Clear stashes, prune remote branches
-6. **Verify** - All changes committed AND pushed
-7. **Hand off** - Provide context for next session
+4. **Sync issue metadata when appropriate** - Run `bd sync` if issue state changed
+5. **Verify local state** - Run `git status` and summarize changed files
+6. **Clean up** - Clear unnecessary stashes or temporary files
+7. **Hand off** - Provide context for next session, including tests run and anything not committed
 
-**CRITICAL RULES:**
-- Work is NOT complete until `git push` succeeds
-- NEVER stop before pushing - that leaves work stranded locally
-- NEVER say "ready to push when you are" - YOU must push
-- If push fails, resolve and retry until it succeeds
+**Rules:**
+- Do not run `git push` unless the user explicitly asks
+- Do not say work was pushed unless `git push` was actually run and succeeded
+- If changes are left local, clearly state that in the handoff

--- a/server/main.py
+++ b/server/main.py
@@ -306,13 +306,20 @@ def playoff_series(season: str = "2023-24"):
         return get_playoff_series(season)
     except HTTPException:
         raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
 
 @app.get("/playoffs/full")
 def playoff_games_and_series(season: str = "2023-24"):
-    return get_playoff_games_and_series(season)
+    try:
+        return get_playoff_games_and_series(season)
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
 
 
 if __name__ == "__main__":

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -31,7 +31,23 @@ _linescore_cache: dict = {}
 
 def get_playoff_end_year(season: str) -> int:
     """Return the calendar year that contains the playoffs for a season."""
-    return int(season.split("-")[0]) + 1
+    if not isinstance(season, str):
+        raise ValueError("Season must be a string in YYYY-YY format")
+
+    parts = season.split("-")
+    if len(parts) != 2 or not all(parts):
+        raise ValueError(f"Invalid season format: {season!r}. Expected YYYY-YY")
+
+    start_year, end_year_suffix = parts
+    if (
+        len(start_year) != 4
+        or len(end_year_suffix) != 2
+        or not start_year.isdigit()
+        or not end_year_suffix.isdigit()
+    ):
+        raise ValueError(f"Invalid season format: {season!r}. Expected YYYY-YY")
+
+    return int(start_year) + 1
 
 
 def get_playoff_format(season: str, finals_round: int | None = None):
@@ -47,6 +63,27 @@ def get_playoff_format(season: str, finals_round: int | None = None):
         bracket_type = "multi-division"
         exact = False
         notes = ["Three-division transitional format; exact source bracket can be ambiguous."]
+    elif playoff_year == 1951:
+        era = "1951-two-division-eight-team"
+        bracket_type = "multi-division"
+        exact = True
+        notes = [
+            "Two-division eight-team format with two-win first round targets and three-win division finals targets."
+        ]
+    elif playoff_year == 1952:
+        era = "1952-two-division-eight-team"
+        bracket_type = "multi-division"
+        exact = True
+        notes = [
+            "Two-division eight-team format with two-win first round targets and three-win division finals targets."
+        ]
+    elif playoff_year == 1953:
+        era = "1953-two-division-eight-team"
+        bracket_type = "multi-division"
+        exact = True
+        notes = [
+            "Two-division eight-team format with two-win first round targets and three-win division finals targets."
+        ]
     elif playoff_year == 1954:
         era = "six-team-round-robin"
         bracket_type = "round-robin-plus-finals"

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -29,6 +29,105 @@ _df_cache: dict = {}
 _linescore_cache: dict = {}
 
 
+def get_playoff_end_year(season: str) -> int:
+    """Return the calendar year that contains the playoffs for a season."""
+    return int(season.split("-")[0]) + 1
+
+
+def get_playoff_format(season: str, finals_round: int | None = None):
+    playoff_year = get_playoff_end_year(season)
+
+    if playoff_year <= 1948:
+        era = "baa-runners-up-bracket"
+        bracket_type = "hybrid"
+        exact = False
+        notes = ["Early BAA runners-up bracket; rendered as grouped historical rounds."]
+    elif playoff_year == 1950:
+        era = "three-division-transitional"
+        bracket_type = "multi-division"
+        exact = False
+        notes = ["Three-division transitional format; exact source bracket can be ambiguous."]
+    elif playoff_year == 1954:
+        era = "six-team-round-robin"
+        bracket_type = "round-robin-plus-finals"
+        exact = False
+        notes = ["Division round-robin format; connectors are shown only when derivable."]
+    elif 1955 <= playoff_year <= 1966:
+        era = "six-team-bye"
+        bracket_type = "multi-division"
+        exact = True
+        notes = ["Six-team format with first-place division byes."]
+    elif 1967 <= playoff_year <= 1970:
+        era = "eight-team-division"
+        bracket_type = "multi-division"
+        exact = True
+        notes = ["Eight-team division format before conference naming."]
+    elif 1971 <= playoff_year <= 1974:
+        era = "eight-team-conference"
+        bracket_type = "single-elimination"
+        exact = True
+        notes = ["Eight-team conference playoff format."]
+    elif 1975 <= playoff_year <= 1976:
+        era = "ten-team-bye"
+        bracket_type = "single-elimination"
+        exact = True
+        notes = ["Ten-team playoff format with first-round byes."]
+    elif 1977 <= playoff_year <= 1983:
+        era = "twelve-team-bye"
+        bracket_type = "single-elimination"
+        exact = True
+        notes = ["Twelve-team playoff format with first-round byes."]
+    elif 1984 <= playoff_year <= 2002:
+        era = "sixteen-team-best-of-five-first-round"
+        bracket_type = "single-elimination"
+        exact = True
+        notes = ["Sixteen-team bracket with a best-of-five first round."]
+    elif 2003 <= playoff_year <= 2019:
+        era = "sixteen-team-best-of-seven"
+        bracket_type = "single-elimination"
+        exact = True
+        notes = ["Sixteen-team bracket with all rounds best-of-seven."]
+    elif playoff_year >= 2020:
+        era = "modern-play-in-era"
+        bracket_type = "single-elimination"
+        exact = True
+        notes = ["Play-in games are outside this playoff series endpoint."]
+    else:
+        era = "two-division-eight-team"
+        bracket_type = "multi-division"
+        exact = True
+        notes = ["Two-division historical playoff format."]
+
+    return {
+        "era": era,
+        "playoffYear": playoff_year,
+        "finalsRound": finals_round,
+        "bracketType": bracket_type,
+        "supportsExactBracket": exact,
+        "notes": notes,
+    }
+
+
+def get_target_wins(playoff_year: int, round_number: int, is_finals: bool):
+    if playoff_year == 1954 and not is_finals:
+        return None
+    if is_finals:
+        return 4
+    if playoff_year <= 1950:
+        return 2
+    if 1951 <= playoff_year <= 1953:
+        return 2 if round_number == 1 else 3
+    if 1955 <= playoff_year <= 1960:
+        return 2 if round_number == 1 else 4
+    if 1961 <= playoff_year <= 1967:
+        return 3 if round_number == 1 else 4
+    if 1975 <= playoff_year <= 1983 and round_number == 1:
+        return 2
+    if 1984 <= playoff_year <= 2002 and round_number == 1:
+        return 3
+    return 4
+
+
 def should_use_active_playoff_source(season: str, today: date | None = None) -> bool:
     today = today or date.today()
     current_season = get_nba_season(today.year, today.month)
@@ -81,6 +180,188 @@ def get_round_name(round_number: int):
         3: "Conference Finals",
         4: "NBA Finals",
     }.get(round_number, f"Round {round_number}")
+
+
+def get_series_dates(series):
+    games = series.get("games") or []
+    if not games:
+        return ("", "")
+    dates = sorted(game["date"] for game in games)
+    return (dates[0], dates[-1])
+
+
+def get_finals_round(playoff_series):
+    if not playoff_series:
+        return None
+
+    by_round = defaultdict(list)
+    for series in playoff_series:
+        by_round[series["round"]].append(series)
+
+    max_round = max(by_round.keys())
+    if len(by_round[max_round]) == 1:
+        return max_round
+
+    return None
+
+
+def get_group_for_series(series, playoff_year: int, is_finals: bool):
+    if is_finals:
+        return {
+            "id": "finals",
+            "label": "NBA Finals",
+            "kind": "finals",
+            "sortOrder": 99,
+        }
+
+    conf = _get_series_conference(series)
+    if conf in {"East", "West"}:
+        if playoff_year < 1971:
+            label = "Eastern Division" if conf == "East" else "Western Division"
+            suffix = "division"
+        else:
+            label = "Eastern Conference" if conf == "East" else "Western Conference"
+            suffix = "conference"
+        return {
+            "id": f"{conf.lower()}-{suffix}",
+            "label": label,
+            "kind": "division" if suffix == "division" else "conference",
+            "sortOrder": 10 if conf == "West" else 20,
+        }
+
+    return {
+        "id": "league",
+        "label": "League Bracket",
+        "kind": "league",
+        "sortOrder": 30,
+    }
+
+
+def get_round_definitions(playoff_series):
+    rounds = {}
+    for series in playoff_series:
+        round_number = series["round"]
+        rounds[round_number] = {
+            "round": round_number,
+            "label": series.get("roundName") or get_round_name(round_number),
+            "sortOrder": round_number,
+            "defaultRevealed": round_number == 1,
+        }
+
+    return [rounds[key] for key in sorted(rounds)]
+
+
+def get_advancement_edges(playoff_series):
+    edges = []
+    series_team_ids = {
+        series["seriesKey"]: {team["id"] for team in series.get("teams", [])}
+        for series in playoff_series
+    }
+
+    for source in playoff_series:
+        winner_id = source.get("winnerTeamId")
+        if not winner_id:
+            continue
+
+        _, source_end = get_series_dates(source)
+        candidates = []
+
+        for target in playoff_series:
+            if target["seriesKey"] == source["seriesKey"]:
+                continue
+            if target["round"] <= source["round"]:
+                continue
+            if winner_id not in series_team_ids.get(target["seriesKey"], set()):
+                continue
+
+            target_start, _ = get_series_dates(target)
+            if source_end and target_start and target_start < source_end:
+                continue
+
+            candidates.append(target)
+
+        if not candidates:
+            continue
+
+        target = min(
+            candidates,
+            key=lambda series: (
+                series["round"],
+                get_series_dates(series)[0],
+                series["seriesKey"],
+            ),
+        )
+        edges.append(
+            {
+                "sourceSeriesKey": source["seriesKey"],
+                "targetSeriesKey": target["seriesKey"],
+                "winnerTeamId": winner_id,
+            }
+        )
+
+    return edges
+
+
+def enrich_playoff_bracket_response(season: str, playoff_series):
+    finals_round = get_finals_round(playoff_series)
+    playoff_format = get_playoff_format(season, finals_round)
+    playoff_year = playoff_format["playoffYear"]
+    groups_by_id = {}
+    enriched_series = []
+
+    for series in playoff_series:
+        series_copy = {
+            **series,
+            "teams": list(series.get("teams", [])),
+            "wins": dict(series.get("wins", {})),
+            "games": list(series.get("games", [])),
+        }
+        is_finals = finals_round is not None and series_copy["round"] == finals_round
+        group = get_group_for_series(series_copy, playoff_year, is_finals)
+        groups_by_id[group["id"]] = group
+
+        if is_finals:
+            series_copy["roundName"] = "NBA Finals"
+
+        series_copy["bracketGroupId"] = group["id"]
+        series_copy["bracketGroupLabel"] = group["label"]
+        series_copy["bracketGroupKind"] = group["kind"]
+        series_copy["targetWins"] = get_target_wins(
+            playoff_year,
+            series_copy["round"],
+            is_finals,
+        )
+        series_copy["isFinals"] = is_finals
+        enriched_series.append(series_copy)
+
+    grouped_positions = defaultdict(int)
+    enriched_series.sort(
+        key=lambda series: (
+            series["round"],
+            groups_by_id[series["bracketGroupId"]]["sortOrder"],
+            get_series_dates(series)[0],
+            series["seriesKey"],
+        )
+    )
+
+    for series in enriched_series:
+        key = (series["bracketGroupId"], series["round"])
+        series["bracketOrder"] = grouped_positions[key]
+        grouped_positions[key] += 1
+
+    groups = sorted(groups_by_id.values(), key=lambda group: group["sortOrder"])
+
+    return {
+        "format": playoff_format,
+        "groups": groups,
+        "rounds": get_round_definitions(enriched_series),
+        "edges": (
+            get_advancement_edges(enriched_series)
+            if playoff_format["supportsExactBracket"]
+            else []
+        ),
+        "series": enriched_series,
+    }
 
 
 def get_matchup_key(game):
@@ -741,13 +1022,18 @@ def get_playoff_series(season: str):
     games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
     playoff_series = derive_playoff_series(games)
+    bracket = enrich_playoff_bracket_response(season, playoff_series)
 
     return {
         "season": season,
         "teamGameRowCount": len(df),
         "gameCount": len(games),
         "seriesCount": len(playoff_series),
-        "series": playoff_series,
+        "format": bracket["format"],
+        "groups": bracket["groups"],
+        "rounds": bracket["rounds"],
+        "edges": bracket["edges"],
+        "series": bracket["series"],
     }
 
 
@@ -757,6 +1043,7 @@ def get_playoff_games_and_series(season: str):
     games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
     playoff_series = derive_playoff_series(games)
+    bracket = enrich_playoff_bracket_response(season, playoff_series)
 
     return {
         "season": season,
@@ -764,5 +1051,9 @@ def get_playoff_games_and_series(season: str):
         "gameCount": len(games),
         "seriesCount": len(playoff_series),
         "games": games,
-        "series": playoff_series,
+        "format": bracket["format"],
+        "groups": bracket["groups"],
+        "rounds": bracket["rounds"],
+        "edges": bracket["edges"],
+        "series": bracket["series"],
     }

--- a/server/tests/test_playoff_format_metadata.py
+++ b/server/tests/test_playoff_format_metadata.py
@@ -1,0 +1,99 @@
+from server.services import playoffs
+
+
+def _series(series_key, round_num, teams, winner, games=None):
+    games = games or [
+        {
+            "gameId": f"{series_key}-1",
+            "date": f"2000-04-{round_num:02d}",
+            "round": round_num,
+            "roundName": playoffs.get_round_name(round_num),
+            "homeTeam": {"id": teams[0][0], "tricode": teams[0][1], "name": teams[0][1], "score": 100},
+            "awayTeam": {"id": teams[1][0], "tricode": teams[1][1], "name": teams[1][1], "score": 90},
+            "winnerTeamId": winner,
+            "winnerTeamAbbreviation": teams[0][1],
+        }
+    ]
+    return {
+        "seriesKey": series_key,
+        "round": round_num,
+        "roundName": playoffs.get_round_name(round_num),
+        "teams": [
+            {"id": teams[0][0], "tricode": teams[0][1], "name": teams[0][1]},
+            {"id": teams[1][0], "tricode": teams[1][1], "name": teams[1][1]},
+        ],
+        "wins": {winner: 1},
+        "winnerTeamId": winner,
+        "winnerTeamTricode": teams[0][1],
+        "gameCount": len(games),
+        "games": games,
+    }
+
+
+def test_1954_round_robin_format_marks_dynamic_finals_round():
+    mnl = 1610612747
+    syr = 1610612755
+    bracket = playoffs.enrich_playoff_bracket_response(
+        "1953-54",
+        [
+            _series("R1-a", 1, [(1610612738, "BOS"), (1610612752, "NYK")], 1610612738),
+            _series("R1-b", 1, [(mnl, "MNL"), (1610612758, "ROC")], mnl),
+            _series("R2-final", 2, [(mnl, "MNL"), (syr, "SYR")], mnl),
+        ],
+    )
+
+    assert bracket["format"]["era"] == "six-team-round-robin"
+    assert bracket["format"]["bracketType"] == "round-robin-plus-finals"
+    assert bracket["format"]["finalsRound"] == 2
+    assert bracket["series"][-1]["isFinals"] is True
+    assert bracket["series"][-1]["roundName"] == "NBA Finals"
+
+
+def test_1984_first_round_uses_best_of_five_target_wins():
+    bracket = playoffs.enrich_playoff_bracket_response(
+        "1983-84",
+        [
+            _series(
+                "R1-bos-was",
+                1,
+                [(1610612738, "BOS"), (1610612764, "WAS")],
+                1610612738,
+            ),
+            _series(
+                "R4-bos-lal",
+                4,
+                [(1610612738, "BOS"), (1610612747, "LAL")],
+                1610612738,
+            ),
+        ],
+    )
+
+    first_round = next(series for series in bracket["series"] if series["round"] == 1)
+    finals = next(series for series in bracket["series"] if series["isFinals"])
+
+    assert bracket["format"]["era"] == "sixteen-team-best-of-five-first-round"
+    assert first_round["targetWins"] == 3
+    assert finals["targetWins"] == 4
+
+
+def test_metadata_includes_groups_rounds_and_advancement_edges():
+    bos = 1610612738
+    nyk = 1610612752
+    lal = 1610612747
+    first = _series("R1-bos-nyk", 1, [(bos, "BOS"), (nyk, "NYK")], bos)
+    final = _series("R2-bos-lal", 2, [(bos, "BOS"), (lal, "LAL")], bos)
+
+    bracket = playoffs.enrich_playoff_bracket_response("1950-51", [first, final])
+
+    assert bracket["groups"]
+    assert bracket["rounds"] == [
+        {"round": 1, "label": "First Round", "sortOrder": 1, "defaultRevealed": True},
+        {"round": 2, "label": "NBA Finals", "sortOrder": 2, "defaultRevealed": False},
+    ]
+    assert bracket["edges"] == [
+        {
+            "sourceSeriesKey": "R1-bos-nyk",
+            "targetSeriesKey": "R2-bos-lal",
+            "winnerTeamId": bos,
+        }
+    ]

--- a/server/tests/test_playoff_format_metadata.py
+++ b/server/tests/test_playoff_format_metadata.py
@@ -1,7 +1,10 @@
+import pytest
+
 from server.services import playoffs
 
 
 def _series(series_key, round_num, teams, winner, games=None):
+    winner_team_abbreviation = teams[0][1] if winner == teams[0][0] else teams[1][1]
     games = games or [
         {
             "gameId": f"{series_key}-1",
@@ -11,7 +14,7 @@ def _series(series_key, round_num, teams, winner, games=None):
             "homeTeam": {"id": teams[0][0], "tricode": teams[0][1], "name": teams[0][1], "score": 100},
             "awayTeam": {"id": teams[1][0], "tricode": teams[1][1], "name": teams[1][1], "score": 90},
             "winnerTeamId": winner,
-            "winnerTeamAbbreviation": teams[0][1],
+            "winnerTeamAbbreviation": winner_team_abbreviation,
         }
     ]
     return {
@@ -47,6 +50,29 @@ def test_1954_round_robin_format_marks_dynamic_finals_round():
     assert bracket["format"]["finalsRound"] == 2
     assert bracket["series"][-1]["isFinals"] is True
     assert bracket["series"][-1]["roundName"] == "NBA Finals"
+
+
+def test_1951_to_1953_formats_have_dedicated_metadata():
+    for year in (1951, 1952, 1953):
+        playoff_format = playoffs.get_playoff_format(f"{year - 1}-{str(year)[-2:]}")
+
+        assert playoff_format["era"] == f"{year}-two-division-eight-team"
+        assert playoff_format["bracketType"] == "multi-division"
+        assert playoff_format["supportsExactBracket"] is True
+        assert playoff_format["notes"]
+
+
+@pytest.mark.parametrize("season", [None, "", "2023", "2023-", "-24", "2023-2024", "abcd-ef"])
+def test_playoff_end_year_rejects_invalid_season_format(season):
+    with pytest.raises(ValueError, match="Expected YYYY-YY|Season must be a string"):
+        playoffs.get_playoff_end_year(season)
+
+
+def test_1951_to_1953_series_targets_match_era_format():
+    for year in (1951, 1952, 1953):
+        assert playoffs.get_target_wins(year, 1, False) == 2
+        assert playoffs.get_target_wins(year, 2, False) == 3
+        assert playoffs.get_target_wins(year, 3, True) == 4
 
 
 def test_1984_first_round_uses_best_of_five_target_wins():
@@ -85,6 +111,7 @@ def test_metadata_includes_groups_rounds_and_advancement_edges():
 
     bracket = playoffs.enrich_playoff_bracket_response("1950-51", [first, final])
 
+    assert bracket["format"]["era"] == "1951-two-division-eight-team"
     assert bracket["groups"]
     assert bracket["rounds"] == [
         {"round": 1, "label": "First Round", "sortOrder": 1, "defaultRevealed": True},

--- a/server/tests/test_playoffs_routes.py
+++ b/server/tests/test_playoffs_routes.py
@@ -1,0 +1,32 @@
+import pytest
+from fastapi import HTTPException
+
+from server import main
+
+
+def test_playoff_series_maps_invalid_season_to_client_error(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "get_playoff_series",
+        lambda season: (_ for _ in ()).throw(ValueError("Invalid season format")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        main.playoff_series("bad")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid season format"
+
+
+def test_playoff_full_maps_invalid_season_to_client_error(monkeypatch):
+    monkeypatch.setattr(
+        main,
+        "get_playoff_games_and_series",
+        lambda season: (_ for _ in ()).throw(ValueError("Invalid season format")),
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        main.playoff_games_and_series("bad")
+
+    assert exc.value.status_code == 400
+    assert exc.value.detail == "Invalid season format"

--- a/src/components/BracketSeriesNode.tsx
+++ b/src/components/BracketSeriesNode.tsx
@@ -11,7 +11,7 @@ interface BracketSeriesNodeProps {
 const HANDLE_STYLE = { background: 'transparent', border: 'none', width: 1, height: 1 };
 
 function BracketSeriesNode({ data }: BracketSeriesNodeProps) {
-  const { team1, team2, team1Wins, team2Wins, winnerTeamId, isRevealed, sizing, conference, seriesSlug, season } = data;
+  const { team1, team2, team1Wins, team2Wins, winnerTeamId, isRevealed, sizing, seriesSlug, season, targetWins } = data;
 
   const team1IsWinner = winnerTeamId === team1.id;
   const team2IsWinner = winnerTeamId === team2.id;
@@ -52,30 +52,15 @@ function BracketSeriesNode({ data }: BracketSeriesNodeProps) {
   return (
     <div style={{ width: `${sizing.nodeWidth}px`, position: 'relative' }}>
       {/* Source handles: exit from the winner row's outer edge toward the next round */}
-      {conference === 'West' && (
-        <>
-          <Handle type="source" position={Position.Right} id="src-top" style={{ ...HANDLE_STYLE, top: '25%' }} />
-          <Handle type="source" position={Position.Right} id="src-bot" style={{ ...HANDLE_STYLE, top: '75%' }} />
-          <Handle type="target" position={Position.Left} id="tgt" style={{ ...HANDLE_STYLE, top: '50%' }} />
-        </>
-      )}
-      {conference === 'East' && (
-        <>
-          <Handle type="source" position={Position.Left} id="src-top" style={{ ...HANDLE_STYLE, top: '25%' }} />
-          <Handle type="source" position={Position.Left} id="src-bot" style={{ ...HANDLE_STYLE, top: '75%' }} />
-          <Handle type="target" position={Position.Right} id="tgt" style={{ ...HANDLE_STYLE, top: '50%' }} />
-        </>
-      )}
-      {conference === 'Finals' && (
-        <>
-          <Handle type="target" position={Position.Left} id="tgt-left" style={{ ...HANDLE_STYLE, top: '50%' }} />
-          <Handle type="target" position={Position.Right} id="tgt-right" style={{ ...HANDLE_STYLE, top: '50%' }} />
-        </>
-      )}
+      <Handle type="source" position={Position.Right} id="src-right" style={{ ...HANDLE_STYLE, top: '50%' }} />
+      <Handle type="source" position={Position.Left} id="src-left" style={{ ...HANDLE_STYLE, top: '50%' }} />
+      <Handle type="target" position={Position.Left} id="tgt-left" style={{ ...HANDLE_STYLE, top: '50%' }} />
+      <Handle type="target" position={Position.Right} id="tgt-right" style={{ ...HANDLE_STYLE, top: '50%' }} />
 
       <Link
         to={`/playoffs/${seasonToYear(season)}/${seriesSlug}`}
         className="block border-2 border-gray-700 rounded-lg bg-gray-900 overflow-hidden hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg transition-all duration-200"
+        title={targetWins ? `Best of ${targetWins * 2 - 1}` : undefined}
       >
         {renderRow(team1, team1Wins, team1IsWinner, true)}
         {renderRow(team2, team2Wins, team2IsWinner, false)}

--- a/src/components/MobileBracket.tsx
+++ b/src/components/MobileBracket.tsx
@@ -1,24 +1,15 @@
 import { useState, useEffect, useRef } from 'react';
-import type { SeriesData } from '@/helpers/helpers';
-import { groupSeriesByConference } from '@/utils/bracketTransformer';
+import type { BracketGroup } from '@/helpers/helpers';
+import type { PlayoffBracketModel, RenderSeries } from '@/utils/playoffBracketModel';
 import MobileSeriesCard from './MobileSeriesCard';
 
-type ConferenceTab = 'West' | 'East' | 'Finals';
-
 interface MobileBracketProps {
-  playoffPicture: SeriesData[];
-  season: string;
+  model: PlayoffBracketModel;
   revealedRounds: Set<number>;
   revealRound: (round: number) => void;
   hideRound: (round: number) => void;
   canRevealRound: (round: number) => boolean;
 }
-
-const TABS: { key: ConferenceTab; label: string }[] = [
-  { key: 'West', label: 'Western' },
-  { key: 'East', label: 'Eastern' },
-  { key: 'Finals', label: 'Finals' },
-];
 
 function RoundSection({
   roundName,
@@ -30,8 +21,8 @@ function RoundSection({
 }: {
   round: number;
   roundName: string;
-  series: SeriesData[];
-  allSeries: SeriesData[];
+  series: RenderSeries[];
+  allSeries: RenderSeries[];
   season: string;
   isRevealed: boolean;
   onToggle: () => void;
@@ -78,7 +69,6 @@ function RoundSection({
       </div>
       {showScrollHint && (
         <div className="fixed bottom-6 left-1/2 -translate-x-1/2 flex items-center gap-2 px-4 py-2 rounded-full bg-gray-800 border border-gray-600 shadow-lg z-50 pointer-events-none">
-          <span className="animate-bounce text-base leading-none">🏀</span>
           <span className="text-xs text-gray-200 whitespace-nowrap">scroll for more</span>
         </div>
       )}
@@ -87,24 +77,22 @@ function RoundSection({
 }
 
 function MobileBracket({
-  playoffPicture,
-  season,
+  model,
   revealedRounds,
   revealRound,
   hideRound,
   canRevealRound,
 }: MobileBracketProps) {
-  const [activeTab, setActiveTab] = useState<ConferenceTab>('West');
+  const visibleGroups = model.groups.filter(group => model.series.some(series => series.bracketGroupId === group.id));
+  const [activeGroupId, setActiveGroupId] = useState(visibleGroups[0]?.id ?? '');
   const [isStuck, setIsStuck] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);
-  const { east, west, finals } = groupSeriesByConference(playoffPicture);
-  const showFinalsTab = canRevealRound(4);
 
   useEffect(() => {
-    if (!showFinalsTab && activeTab === 'Finals') {
-      setActiveTab('West');
+    if (!visibleGroups.some(group => group.id === activeGroupId)) {
+      setActiveGroupId(visibleGroups[0]?.id ?? '');
     }
-  }, [showFinalsTab, activeTab]);
+  }, [activeGroupId, visibleGroups]);
 
   useEffect(() => {
     const sentinel = sentinelRef.current;
@@ -117,26 +105,37 @@ function MobileBracket({
     return () => observer.disconnect();
   }, []);
 
-  const renderConference = (confSeries: SeriesData[]) => {
-    const rounds = [...new Set(confSeries.map(s => s.round))].sort((a, b) => a - b);
-    const visibleRounds = rounds.filter(r => canRevealRound(r));
+  const renderGroup = (group: BracketGroup) => {
+    const groupSeries = model.series.filter(series => series.bracketGroupId === group.id);
+    const visibleRounds = model.rounds.filter(round =>
+      canRevealRound(round.round) && groupSeries.some(series => series.round === round.round)
+    );
+
+    if (visibleRounds.length === 0) {
+      return (
+        <p className="text-sm text-gray-400 text-center py-6">
+          Reveal earlier results to unlock this round.
+        </p>
+      );
+    }
 
     return (
       <div className="flex flex-col gap-6">
         {visibleRounds.map(round => {
-          const roundSeries = confSeries.filter(s => s.round === round);
-          const roundName = roundSeries[0]?.roundName ?? `Round ${round}`;
+          const roundSeries = groupSeries
+            .filter(series => series.round === round.round)
+            .sort((a, b) => a.bracketOrder - b.bracketOrder);
           return (
             <RoundSection
-              key={round}
-              round={round}
-              roundName={roundName}
+              key={round.round}
+              round={round.round}
+              roundName={round.label}
               series={roundSeries}
-              allSeries={playoffPicture}
-              season={season}
-              isRevealed={revealedRounds.has(round)}
+              allSeries={model.series}
+              season={model.season}
+              isRevealed={revealedRounds.has(round.round)}
               onToggle={() =>
-                revealedRounds.has(round) ? hideRound(round) : revealRound(round)
+                revealedRounds.has(round.round) ? hideRound(round.round) : revealRound(round.round)
               }
             />
           );
@@ -145,58 +144,28 @@ function MobileBracket({
     );
   };
 
-  const renderFinals = () => {
-    if (!canRevealRound(4)) {
-      return (
-        <p className="text-sm text-gray-400 text-center py-6">
-          Reveal Conference Finals results to unlock the NBA Finals
-        </p>
-      );
-    }
-    if (finals.length === 0) {
-      return (
-        <p className="text-sm text-gray-400 text-center py-6">
-          NBA Finals matchup not yet set
-        </p>
-      );
-    }
-    const roundName = finals[0].roundName;
-    const isRevealed = revealedRounds.has(4);
-    return (
-      <RoundSection
-        round={4}
-        roundName={roundName}
-        series={finals}
-        allSeries={playoffPicture}
-        season={season}
-        isRevealed={isRevealed}
-        onToggle={() => (isRevealed ? hideRound(4) : revealRound(4))}
-      />
-    );
-  };
+  const activeGroup = visibleGroups.find(group => group.id === activeGroupId) ?? visibleGroups[0];
 
   return (
     <div className="pb-8">
       <div ref={sentinelRef} className="h-0" />
-      <div className={`flex border-b-2 border-gray-700 mb-5 sticky top-0 z-10 transition-colors duration-150 ${isStuck ? 'bg-gray-900' : ''}`}>
-        {TABS.filter(({ key }) => key !== 'Finals' || showFinalsTab).map(({ key, label }) => (
+      <div className={`flex overflow-x-auto border-b-2 border-gray-700 mb-5 sticky top-0 z-10 transition-colors duration-150 ${isStuck ? 'bg-gray-900' : ''}`}>
+        {visibleGroups.map(group => (
           <button
-            key={key}
-            onClick={() => setActiveTab(key)}
-            className={`flex-1 py-2 text-sm font-semibold transition-colors duration-150 ${
-              activeTab === key
+            key={group.id}
+            onClick={() => setActiveGroupId(group.id)}
+            className={`min-w-fit flex-1 px-3 py-2 text-sm font-semibold transition-colors duration-150 ${
+              activeGroup?.id === group.id
                 ? 'text-amber-500 border-b-2 border-amber-500 -mb-0.5'
                 : 'text-gray-400 hover:text-gray-200'
             }`}
           >
-            {label}
+            {group.kind === 'finals' ? 'Finals' : group.label.replace(' Conference', '').replace(' Division', '')}
           </button>
         ))}
       </div>
 
-      {activeTab === 'West' && renderConference(west)}
-      {activeTab === 'East' && renderConference(east)}
-      {activeTab === 'Finals' && renderFinals()}
+      {activeGroup && renderGroup(activeGroup)}
     </div>
   );
 }

--- a/src/components/MobileBracket.tsx
+++ b/src/components/MobileBracket.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import type { BracketGroup } from '@/helpers/helpers';
 import type { PlayoffBracketModel, RenderSeries } from '@/utils/playoffBracketModel';
 import MobileSeriesCard from './MobileSeriesCard';
@@ -83,7 +83,10 @@ function MobileBracket({
   hideRound,
   canRevealRound,
 }: MobileBracketProps) {
-  const visibleGroups = model.groups.filter(group => model.series.some(series => series.bracketGroupId === group.id));
+  const visibleGroups = useMemo(
+    () => model.groups.filter(group => model.series.some(series => series.bracketGroupId === group.id)),
+    [model.groups, model.series]
+  );
   const [activeGroupId, setActiveGroupId] = useState(visibleGroups[0]?.id ?? '');
   const [isStuck, setIsStuck] = useState(false);
   const sentinelRef = useRef<HTMLDivElement>(null);

--- a/src/components/MobileSeriesCard.tsx
+++ b/src/components/MobileSeriesCard.tsx
@@ -58,6 +58,11 @@ function MobileSeriesCard({ series, allSeries, season, isRevealed }: MobileSerie
       to={`/playoffs/${seasonToYear(season)}/${seriesSlug}`}
       className="block border-2 border-gray-700 rounded-lg overflow-hidden hover:border-blue-400 dark:hover:border-blue-400 transition-colors duration-200"
     >
+      {series.targetWins && (
+        <div className="px-3 py-1 bg-gray-800 text-[10px] uppercase tracking-widest text-gray-400">
+          Best of {series.targetWins * 2 - 1}
+        </div>
+      )}
       {renderRow(team1, team1Wins, team1IsWinner, true)}
       {renderRow(team2, team2Wins, team2IsWinner, false)}
     </Link>

--- a/src/components/PlayoffBracketFlow.tsx
+++ b/src/components/PlayoffBracketFlow.tsx
@@ -4,9 +4,10 @@ import { ReactFlow, ReactFlowProvider, useReactFlow, useNodes } from '@xyflow/re
 import type { Node, EdgeTypes } from '@xyflow/react';
 import { Switch } from '@adobe/react-spectrum';
 import '@xyflow/react/dist/style.css';
-import type { SeriesData } from '@/helpers/helpers';
+import type { PlayoffBracketResponse } from '@/helpers/helpers';
 import { transformToBracketData } from '@/utils/bracketTransformer';
 import type { BracketNodeData } from '@/utils/bracketTransformer';
+import { buildPlayoffBracketModel, canRevealRound as canRevealRoundFromModel } from '@/utils/playoffBracketModel';
 import { seasonToYear } from '@/utils/seriesSlug';
 import { bracketSizing } from '@/utils/bracketSizing';
 import { useViewportSize } from '@/hooks/useViewportSize';
@@ -109,19 +110,20 @@ const edgeTypes: EdgeTypes = {
 };
 
 interface PlayoffBracketFlowProps {
-  playoffPicture: SeriesData[];
-  season: string;
+  playoffPicture: PlayoffBracketResponse;
 }
 
-function PlayoffBracketFlowInner({ playoffPicture, season }: PlayoffBracketFlowProps) {
+function PlayoffBracketFlowInner({ playoffPicture }: PlayoffBracketFlowProps) {
   const navigate = useNavigate();
   const viewportSize = useViewportSize();
   const sizing = bracketSizing[viewportSize];
   const [revealedRounds, setRevealedRounds] = useState<Set<number>>(new Set());
+  const model = useMemo(() => buildPlayoffBracketModel(playoffPicture), [playoffPicture]);
+  const season = model.season;
 
   const rounds = useMemo(
-    () => [...new Set(playoffPicture.map(s => s.round))].sort((a, b) => a - b),
-    [playoffPicture]
+    () => model.rounds,
+    [model.rounds]
   );
 
   const revealRound = (round: number) => {
@@ -145,23 +147,18 @@ function PlayoffBracketFlowInner({ playoffPicture, season }: PlayoffBracketFlowP
   }, [navigate]);
 
   const { nodes, edges } = useMemo(
-    () => transformToBracketData(playoffPicture, revealedRounds, season, sizing),
-    [playoffPicture, revealedRounds, season, sizing]
+    () => transformToBracketData(model, revealedRounds, season, sizing),
+    [model, revealedRounds, season, sizing]
   );
 
   const canRevealRound = (round: number): boolean => {
-    if (round === 1) return true;
-    if (round === 2) return revealedRounds.has(1);
-    if (round === 3) return revealedRounds.has(2);
-    if (round === 4) return revealedRounds.has(3);
-    return false;
+    return canRevealRoundFromModel(round, model.rounds, revealedRounds);
   };
 
   if (viewportSize === 'sm') {
     return (
       <MobileBracket
-        playoffPicture={playoffPicture}
-        season={season}
+        model={model}
         revealedRounds={revealedRounds}
         revealRound={revealRound}
         hideRound={hideRound}
@@ -174,10 +171,11 @@ function PlayoffBracketFlowInner({ playoffPicture, season }: PlayoffBracketFlowP
     <>
       {/* Per-round reveal controls */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:flex lg:flex-row lg:flex-wrap lg:justify-center gap-x-8 gap-y-3 mb-6 mx-auto w-fit lg:w-auto justify-items-start">
-        {rounds.map(round => {
+        {rounds.map(roundDef => {
+          const round = roundDef.round;
           const isRevealed = revealedRounds.has(round);
           const canReveal = canRevealRound(round);
-          const roundName = playoffPicture.find(s => s.round === round)?.roundName || `Round ${round}`;
+          const roundName = roundDef.label;
 
           if (!canReveal) return null;
 

--- a/src/components/PlayoffBracketFlow.tsx
+++ b/src/components/PlayoffBracketFlow.tsx
@@ -189,7 +189,7 @@ function PlayoffBracketFlowInner({ playoffPicture, season }: PlayoffBracketFlowP
               UNSAFE_className="origin-left scale-75 sm:scale-100"
             >
               <div className="dark:text-slate-50 text-neutral-950">
-                {isRevealed ? `Hide ${roundName}` : `Show ${roundName}`}
+                {isRevealed ? `Hide ${roundName}` : `Show ${roundName} Results`}
               </div>
             </Switch>
           );

--- a/src/components/PlayoffYearPicker.tsx
+++ b/src/components/PlayoffYearPicker.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router";
 
 const current_year = new Date().getFullYear();
+const first_playoff_end_year = 1951;
 const playoff_start_month = 3; // April (0-indexed)
 const playoff_start_day = 15;
 
@@ -30,8 +31,8 @@ const getDefaultPlayoffEndYear = (date = new Date()) => {
 const default_playoff_end_year = getDefaultPlayoffEndYear();
 
 const season_years = Array.from(
-  { length: current_year - 1983 },
-  (_, i) => 1984 + i,
+  { length: current_year - first_playoff_end_year + 1 },
+  (_, i) => first_playoff_end_year + i,
 ).reverse();
 
 const formatSeason = (year: number) =>

--- a/src/helpers/helpers.tsx
+++ b/src/helpers/helpers.tsx
@@ -26,6 +26,52 @@ export type TeamsInSeries = {
   name: string;
 };
 
+export type PlayoffFormatEra =
+  | "baa-runners-up-bracket"
+  | "two-division-eight-team"
+  | "three-division-transitional"
+  | "six-team-round-robin"
+  | "six-team-bye"
+  | "eight-team-division"
+  | "eight-team-conference"
+  | "ten-team-bye"
+  | "twelve-team-bye"
+  | "sixteen-team-best-of-five-first-round"
+  | "sixteen-team-best-of-seven"
+  | "modern-play-in-era"
+  | "unknown";
+
+export type BracketGroupKind = "conference" | "division" | "league" | "finals" | "runners-up" | "round-robin";
+
+export type PlayoffFormat = {
+  era: PlayoffFormatEra;
+  playoffYear: number;
+  finalsRound: number | null;
+  bracketType: "single-elimination" | "multi-division" | "round-robin-plus-finals" | "hybrid";
+  supportsExactBracket: boolean;
+  notes: string[];
+};
+
+export type BracketGroup = {
+  id: string;
+  label: string;
+  kind: BracketGroupKind;
+  sortOrder: number;
+};
+
+export type RoundDefinition = {
+  round: number;
+  label: string;
+  sortOrder: number;
+  defaultRevealed: boolean;
+};
+
+export type BracketEdge = {
+  sourceSeriesKey: string;
+  targetSeriesKey: string;
+  winnerTeamId: number | null;
+};
+
 export type SeriesGame = {
   gameId: string;
   date: string;
@@ -41,6 +87,13 @@ export type SeriesData = {
   seriesKey: string;
   round: number;
   roundName: string;
+  bracketGroupId?: string;
+  bracketGroupLabel?: string;
+  bracketGroupKind?: BracketGroupKind;
+  bracketOrder?: number;
+  targetWins?: number | null;
+  isFinals?: boolean;
+  isByePlaceholder?: boolean;
   teams: TeamsInSeries[];
   wins: Record<string, number>;
   winnerTeamId: number | null;
@@ -54,6 +107,10 @@ export type PlayoffBracketResponse = {
   teamGameRowCount: number;
   gameCount: number;
   seriesCount: number;
+  format?: PlayoffFormat;
+  groups?: BracketGroup[];
+  rounds?: RoundDefinition[];
+  edges?: BracketEdge[];
   series: SeriesData[];
 };
 

--- a/src/helpers/helpers.tsx
+++ b/src/helpers/helpers.tsx
@@ -30,6 +30,9 @@ export type PlayoffFormatEra =
   | "baa-runners-up-bracket"
   | "two-division-eight-team"
   | "three-division-transitional"
+  | "1951-two-division-eight-team"
+  | "1952-two-division-eight-team"
+  | "1953-two-division-eight-team"
   | "six-team-round-robin"
   | "six-team-bye"
   | "eight-team-division"
@@ -43,34 +46,34 @@ export type PlayoffFormatEra =
 
 export type BracketGroupKind = "conference" | "division" | "league" | "finals" | "runners-up" | "round-robin";
 
-export type PlayoffFormat = {
+export interface PlayoffFormat {
   era: PlayoffFormatEra;
   playoffYear: number;
   finalsRound: number | null;
   bracketType: "single-elimination" | "multi-division" | "round-robin-plus-finals" | "hybrid";
   supportsExactBracket: boolean;
   notes: string[];
-};
+}
 
-export type BracketGroup = {
+export interface BracketGroup {
   id: string;
   label: string;
   kind: BracketGroupKind;
   sortOrder: number;
-};
+}
 
-export type RoundDefinition = {
+export interface RoundDefinition {
   round: number;
   label: string;
   sortOrder: number;
   defaultRevealed: boolean;
-};
+}
 
-export type BracketEdge = {
+export interface BracketEdge {
   sourceSeriesKey: string;
   targetSeriesKey: string;
   winnerTeamId: number | null;
-};
+}
 
 export type SeriesGame = {
   gameId: string;

--- a/src/routes/playoffs/Playoffs.tsx
+++ b/src/routes/playoffs/Playoffs.tsx
@@ -41,8 +41,7 @@ function Playoffs() {
         {data && (
           <div className="mt-8">
             <PlayoffBracketFlow
-              playoffPicture={data.series}
-              season={data.season}
+              playoffPicture={data}
             />
           </div>
         )}

--- a/src/utils/bracketTransformer.ts
+++ b/src/utils/bracketTransformer.ts
@@ -45,6 +45,12 @@ function isModernTwoConferenceModel(model: PlayoffBracketModel): boolean {
   return groupIds.has('west-conference') && groupIds.has('east-conference') && groupIds.has('finals');
 }
 
+function getFinalsRound(model: PlayoffBracketModel): number {
+  if (model.format.finalsRound !== null) return model.format.finalsRound;
+  if (model.rounds.length === 0) return 1;
+  return Math.max(...model.rounds.map(item => item.round));
+}
+
 function getModernPosition(
   series: RenderSeries,
   model: PlayoffBracketModel,
@@ -54,7 +60,7 @@ function getModernPosition(
   const round = series.round;
   const order = series.bracketOrder;
   const lane = series.bracketGroupId.startsWith('east') ? 'right' : series.bracketGroupId.startsWith('west') ? 'left' : 'center';
-  const finalsRound = model.format.finalsRound ?? Math.max(...model.rounds.map(item => item.round));
+  const finalsRound = getFinalsRound(model);
   const maxConferenceRound = Math.max(1, finalsRound - 1);
   const rightEdge = hSpacing * maxConferenceRound * 2;
 
@@ -203,7 +209,7 @@ function createGroupLabels(
 ): Node[] {
   const { hSpacing, nodeWidth, vSpacing } = sizing;
   if (modernLayout) {
-    const finalsRound = model.format.finalsRound ?? Math.max(...model.rounds.map(item => item.round));
+    const finalsRound = getFinalsRound(model);
     const maxConferenceRound = Math.max(1, finalsRound - 1);
     return [
       {

--- a/src/utils/bracketTransformer.ts
+++ b/src/utils/bracketTransformer.ts
@@ -1,8 +1,10 @@
-import type { Node, Edge } from '@xyflow/react';
-import type { SeriesData, TeamsInSeries, SeriesGame } from '@/helpers/helpers';
-import { getTeamConference } from '@/constants/nbaTeams';
+import type { Edge, Node } from '@xyflow/react';
+import type { SeriesGame, TeamsInSeries } from '@/helpers/helpers';
 import type { BracketSizing } from '@/utils/bracketSizing';
 import { buildSeriesSlug } from '@/utils/seriesSlug';
+import type { PlayoffBracketModel, RenderSeries } from '@/utils/playoffBracketModel';
+
+export type BracketLane = 'left' | 'right' | 'center';
 
 export type BracketNodeData = {
   seriesKey: string;
@@ -14,365 +16,246 @@ export type BracketNodeData = {
   team1Wins: number;
   team2Wins: number;
   winnerTeamId: number | null;
-  conference: 'East' | 'West' | 'Finals';
+  lane: BracketLane;
+  bracketGroupId: string;
+  bracketGroupLabel: string;
   games: SeriesGame[];
   season: string;
   isRevealed: boolean;
   sizing: BracketSizing;
+  targetWins: number | null;
+  isFinals: boolean;
 };
 
-type ConferenceGroups = {
-  east: SeriesData[];
-  west: SeriesData[];
-  finals: SeriesData[];
-};
-
-/**
- * Groups playoff series by conference (East, West, Finals)
- */
-export function groupSeriesByConference(series: SeriesData[]): ConferenceGroups {
-  const east: SeriesData[] = [];
-  const west: SeriesData[] = [];
-  const finals: SeriesData[] = [];
-
-  for (const s of series) {
-    // NBA Finals is round 4
-    if (s.round === 4) {
-      finals.push(s);
-      continue;
-    }
-
-    // Determine conference by first team's ID
-    const team1Conference = getTeamConference(s.teams[0].id);
-
-    if (team1Conference === 'East') {
-      east.push(s);
-    } else if (team1Conference === 'West') {
-      west.push(s);
-    } else {
-      // Fallback: if we can't determine, try second team
-      const team2Conference = getTeamConference(s.teams[1].id);
-      if (team2Conference === 'East') {
-        east.push(s);
-      } else if (team2Conference === 'West') {
-        west.push(s);
-      }
-    }
-  }
-
-  return { east, west, finals };
+function groupBy<T>(items: T[], getKey: (item: T) => string): Record<string, T[]> {
+  return items.reduce<Record<string, T[]>>((acc, item) => {
+    const key = getKey(item);
+    acc[key] = acc[key] ?? [];
+    acc[key].push(item);
+    return acc;
+  }, {});
 }
 
-/**
- * Calculates the x,y position for a node in the bracket layout.
- * West progresses left→right; East progresses right→left; Finals sits between.
- */
-function getNodePosition(
-  conference: 'East' | 'West' | 'Finals',
-  round: number,
-  indexInRound: number,
-  hSpacing: number,
-  vSpacing: number
-): { x: number; y: number } {
-  // Calculate Y position
-  let y: number;
-
-  if (conference === 'Finals') {
-    // Finals sits at the same vertical level as Conference Finals (round 3)
-    const confFinalsMultiplier = Math.pow(2, 3 - 1);
-    y = (vSpacing * (confFinalsMultiplier - 1)) / 2;
-  } else {
-    // Each subsequent round has fewer series; space them out and center vs previous round
-    const roundMultiplier = Math.pow(2, round - 1);
-    y = (indexInRound * vSpacing * roundMultiplier) +
-        (vSpacing * (roundMultiplier - 1) / 2);
-  }
-
-  // Calculate X position based on conference and round
-  // 6 = 3 conference rounds × 2 (mirrored East/West layout)
-  const TOTAL_HORIZONTAL_UNITS = 6;
-  let x: number;
-  const eastRightEdge = hSpacing * TOTAL_HORIZONTAL_UNITS;
-
-  if (conference === 'Finals') {
-    x = hSpacing * 3; // midpoint between West Conf Finals (2*hSpacing) and East Conf Finals (4*hSpacing)
-  } else if (conference === 'West') {
-    x = (round - 1) * hSpacing;
-  } else { // East
-    x = eastRightEdge - ((round - 1) * hSpacing);
-  }
-
-  return { x, y };
+export function groupSeriesByBracketGroup(model: PlayoffBracketModel): Record<string, RenderSeries[]> {
+  return groupBy(model.series, series => series.bracketGroupId);
 }
 
-/**
- * Creates edges connecting series winners to their next round matchups
- */
-function createBracketEdges(
-  nodes: Node<BracketNodeData>[],
-  revealedRounds: Set<number>
-): Edge[] {
-  const edges: Edge[] = [];
+function isModernTwoConferenceModel(model: PlayoffBracketModel): boolean {
+  const groupIds = new Set(model.groups.map(group => group.id));
+  return groupIds.has('west-conference') && groupIds.has('east-conference') && groupIds.has('finals');
+}
 
-  // Group nodes by conference and round for easier lookup
-  const nodesByConference: Record<string, Record<number, Node<BracketNodeData>[]>> = {
-    East: {},
-    West: {},
-    Finals: {}
+function getModernPosition(
+  series: RenderSeries,
+  model: PlayoffBracketModel,
+  sizing: BracketSizing,
+): { position: { x: number; y: number }; lane: BracketLane } {
+  const { hSpacing, vSpacing } = sizing;
+  const round = series.round;
+  const order = series.bracketOrder;
+  const lane = series.bracketGroupId.startsWith('east') ? 'right' : series.bracketGroupId.startsWith('west') ? 'left' : 'center';
+  const finalsRound = model.format.finalsRound ?? Math.max(...model.rounds.map(item => item.round));
+  const maxConferenceRound = Math.max(1, finalsRound - 1);
+  const rightEdge = hSpacing * maxConferenceRound * 2;
+
+  const multiplier = Math.max(1, Math.pow(2, round - 1));
+  const y = series.isFinals
+    ? (vSpacing * (Math.pow(2, Math.max(0, maxConferenceRound - 1)) - 1)) / 2
+    : (order * vSpacing * multiplier) + ((vSpacing * (multiplier - 1)) / 2);
+
+  if (series.isFinals) {
+    return { position: { x: hSpacing * maxConferenceRound, y }, lane: 'center' };
+  }
+  if (lane === 'right') {
+    return { position: { x: rightEdge - ((round - 1) * hSpacing), y }, lane };
+  }
+  return { position: { x: (round - 1) * hSpacing, y }, lane };
+}
+
+function getHistoricalPosition(
+  series: RenderSeries,
+  model: PlayoffBracketModel,
+  sizing: BracketSizing,
+): { position: { x: number; y: number }; lane: BracketLane } {
+  const { hSpacing, vSpacing } = sizing;
+  const nonFinalGroups = model.groups.filter(group => group.kind !== 'finals');
+  const groupIndex = Math.max(0, nonFinalGroups.findIndex(group => group.id === series.bracketGroupId));
+  const maxRows = Math.max(1, ...nonFinalGroups.map(group => {
+    return Math.max(
+      1,
+      ...model.rounds.map(round => model.series.filter(item => item.bracketGroupId === group.id && item.round === round.round).length),
+    );
+  }));
+  const laneHeight = Math.max(vSpacing * (maxRows + 1), vSpacing * 2);
+  const x = (model.rounds.findIndex(round => round.round === series.round)) * hSpacing;
+
+  if (series.isFinals) {
+    return {
+      position: {
+        x,
+        y: (nonFinalGroups.length * laneHeight) / 2 - (vSpacing / 2),
+      },
+      lane: 'center',
+    };
+  }
+
+  return {
+    position: {
+      x,
+      y: groupIndex * laneHeight + (series.bracketOrder * vSpacing),
+    },
+    lane: 'center',
   };
-
-  nodes.forEach(node => {
-    const conf = node.data.conference;
-    const round = node.data.round;
-    if (!nodesByConference[conf][round]) {
-      nodesByConference[conf][round] = [];
-    }
-    nodesByConference[conf][round].push(node);
-  });
-
-  // Create edges for each conference
-  ['East', 'West'].forEach(conf => {
-    const conferenceNodes = nodesByConference[conf];
-    const rounds = Object.keys(conferenceNodes).map(Number).sort((a, b) => a - b);
-
-    rounds.forEach(round => {
-      const nextRound = round + 1;
-      const currentRoundNodes = conferenceNodes[round] || [];
-      const nextRoundNodes = conferenceNodes[nextRound] || [];
-
-      // Sort current round nodes by their Y position to match them correctly
-      const sortedCurrentNodes = [...currentRoundNodes].sort((a, b) =>
-        a.position.y - b.position.y
-      );
-
-      sortedCurrentNodes.forEach((sourceNode, idx) => {
-        // Only create edge if the series has a winner and the round is revealed
-        if (sourceNode.data.winnerTeamId && revealedRounds.has(round)) {
-          // Each pair of series feeds into one series in the next round
-          const targetNodeIndex = Math.floor(idx / 2);
-          const targetNode = nextRoundNodes[targetNodeIndex];
-
-          if (targetNode) {
-            const winnerIsTeam1 = sourceNode.data.winnerTeamId === sourceNode.data.team1.id;
-            edges.push({
-              id: `e-${sourceNode.id}-${targetNode.id}`,
-              source: sourceNode.id,
-              sourceHandle: winnerIsTeam1 ? 'src-top' : 'src-bot',
-              target: targetNode.id,
-              targetHandle: 'tgt',
-              animated: false,
-              style: {
-                stroke: '#f59e0b',
-                strokeWidth: 2,
-              },
-              type: 'bracketEdge',
-            });
-          }
-        }
-      });
-    });
-  });
-
-  // Create edges from Conference Finals to NBA Finals
-  const eastConfFinals = nodesByConference.East[3]?.[0];
-  const westConfFinals = nodesByConference.West[3]?.[0];
-  const finals = nodesByConference.Finals[4]?.[0];
-
-  if (eastConfFinals && finals && eastConfFinals.data.winnerTeamId && revealedRounds.has(3)) {
-    const winnerIsTeam1 = eastConfFinals.data.winnerTeamId === eastConfFinals.data.team1.id;
-    edges.push({
-      id: `e-${eastConfFinals.id}-${finals.id}`,
-      source: eastConfFinals.id,
-      sourceHandle: winnerIsTeam1 ? 'src-top' : 'src-bot',
-      target: finals.id,
-      targetHandle: 'tgt-right',
-      animated: false,
-      style: { stroke: '#f59e0b', strokeWidth: 2 },
-      type: 'bracketEdge',
-    });
-  }
-
-  if (westConfFinals && finals && westConfFinals.data.winnerTeamId && revealedRounds.has(3)) {
-    const winnerIsTeam1 = westConfFinals.data.winnerTeamId === westConfFinals.data.team1.id;
-    edges.push({
-      id: `e-${westConfFinals.id}-${finals.id}`,
-      source: westConfFinals.id,
-      sourceHandle: winnerIsTeam1 ? 'src-top' : 'src-bot',
-      target: finals.id,
-      targetHandle: 'tgt-left',
-      animated: false,
-      style: { stroke: '#f59e0b', strokeWidth: 2 },
-      type: 'bracketEdge',
-    });
-  }
-
-  return edges;
 }
 
-/**
- * Determines if a round should be visible based on revealed rounds
- */
-function shouldShowRound(round: number, revealedRounds: Set<number>): boolean {
-  // Round 1 is always visible
-  if (round === 1) return true;
-
-  // Round 2 is visible if Round 1 is revealed
-  if (round === 2) return revealedRounds.has(1);
-
-  // Round 3 is visible if Round 2 is revealed
-  if (round === 3) return revealedRounds.has(2);
-
-  // Round 4 (Finals) is visible if Round 3 is revealed
-  if (round === 4) return revealedRounds.has(3);
-
-  return false;
+function shouldShowSeries(series: RenderSeries, model: PlayoffBracketModel, revealedRounds: Set<number>): boolean {
+  const roundIndex = model.rounds.findIndex(round => round.round === series.round);
+  if (roundIndex <= 0) return true;
+  return model.rounds.slice(0, roundIndex).every(round => revealedRounds.has(round.round));
 }
 
-/**
- * Transforms playoff series data into React Flow nodes and edges
- */
-export function transformToBracketData(
-  playoffSeries: SeriesData[],
+function buildNode(
+  series: RenderSeries,
+  model: PlayoffBracketModel,
   revealedRounds: Set<number>,
   season: string,
-  sizing: BracketSizing
-): { nodes: Node[]; edges: Edge[] } {
-  const { east, west, finals } = groupSeriesByConference(playoffSeries);
-  const { hSpacing, vSpacing } = sizing;
+  sizing: BracketSizing,
+  modernLayout: boolean,
+): Node<BracketNodeData> | null {
+  if (!shouldShowSeries(series, model, revealedRounds)) return null;
+  const [team1, team2] = series.teams;
+  if (!team1 || !team2) return null;
+  const { position, lane } = modernLayout
+    ? getModernPosition(series, model, sizing)
+    : getHistoricalPosition(series, model, sizing);
 
-  const nodes: Node[] = [];
+  return {
+    id: series.seriesKey,
+    type: 'seriesNode',
+    position,
+    data: {
+      seriesKey: series.seriesKey,
+      seriesSlug: buildSeriesSlug(series, model.series),
+      round: series.round,
+      roundName: series.roundName,
+      team1,
+      team2,
+      team1Wins: series.wins[team1.id] || 0,
+      team2Wins: series.wins[team2.id] || 0,
+      winnerTeamId: series.winnerTeamId,
+      lane,
+      bracketGroupId: series.bracketGroupId,
+      bracketGroupLabel: series.bracketGroupLabel,
+      games: series.games,
+      season,
+      isRevealed: revealedRounds.has(series.round),
+      sizing,
+      targetWins: series.targetWins,
+      isFinals: series.isFinals,
+    },
+  };
+}
 
-  // Process East conference series
-  const eastByRound: Record<number, SeriesData[]> = {};
-  east.forEach(series => {
-    if (!eastByRound[series.round]) eastByRound[series.round] = [];
-    eastByRound[series.round].push(series);
-  });
+function createBracketEdges(
+  nodes: Node<BracketNodeData>[],
+  model: PlayoffBracketModel,
+  revealedRounds: Set<number>,
+): Edge[] {
+  const nodeIds = new Set(nodes.map(node => node.id));
+  const seriesByKey = new Map(model.series.map(series => [series.seriesKey, series]));
 
-  Object.entries(eastByRound).forEach(([round, seriesList]) => {
-    const roundNum = parseInt(round);
-    if (!shouldShowRound(roundNum, revealedRounds)) return;
-
-    seriesList.forEach((series, index) => {
-      const [team1, team2] = series.teams;
-      const position = getNodePosition('East', roundNum, index, hSpacing, vSpacing);
-
-      nodes.push({
-        id: series.seriesKey,
-        type: 'seriesNode',
-        position,
-        data: {
-          seriesKey: series.seriesKey,
-          seriesSlug: buildSeriesSlug(series, playoffSeries),
-          round: series.round,
-          roundName: series.roundName,
-          team1,
-          team2,
-          team1Wins: series.wins[team1.id] || 0,
-          team2Wins: series.wins[team2.id] || 0,
-          winnerTeamId: series.winnerTeamId,
-          conference: 'East',
-          games: series.games,
-          season,
-          isRevealed: revealedRounds.has(series.round),
-          sizing,
-        },
-      });
-    });
-  });
-
-  // Process West conference series
-  const westByRound: Record<number, SeriesData[]> = {};
-  west.forEach(series => {
-    if (!westByRound[series.round]) westByRound[series.round] = [];
-    westByRound[series.round].push(series);
-  });
-
-  Object.entries(westByRound).forEach(([round, seriesList]) => {
-    const roundNum = parseInt(round);
-    if (!shouldShowRound(roundNum, revealedRounds)) return;
-
-    seriesList.forEach((series, index) => {
-      const [team1, team2] = series.teams;
-      const position = getNodePosition('West', roundNum, index, hSpacing, vSpacing);
-
-      nodes.push({
-        id: series.seriesKey,
-        type: 'seriesNode',
-        position,
-        data: {
-          seriesKey: series.seriesKey,
-          seriesSlug: buildSeriesSlug(series, playoffSeries),
-          round: series.round,
-          roundName: series.roundName,
-          team1,
-          team2,
-          team1Wins: series.wins[team1.id] || 0,
-          team2Wins: series.wins[team2.id] || 0,
-          winnerTeamId: series.winnerTeamId,
-          conference: 'West',
-          games: series.games,
-          season,
-          isRevealed: revealedRounds.has(series.round),
-          sizing,
-        },
-      });
-    });
-  });
-
-  // Process NBA Finals (round 4) — visible once round 3 is revealed
-  if (shouldShowRound(4, revealedRounds)) {
-    finals.forEach(series => {
-      const [team1, team2] = series.teams;
-      const position = getNodePosition('Finals', 4, 0, hSpacing, vSpacing);
-
-      nodes.push({
-        id: series.seriesKey,
-        type: 'seriesNode',
-        position,
-        data: {
-          seriesKey: series.seriesKey,
-          seriesSlug: buildSeriesSlug(series, playoffSeries),
-          round: series.round,
-          roundName: series.roundName,
-          team1,
-          team2,
-          team1Wins: series.wins[team1.id] || 0,
-          team2Wins: series.wins[team2.id] || 0,
-          winnerTeamId: series.winnerTeamId,
-          conference: 'Finals',
-          games: series.games,
-          season,
-          isRevealed: revealedRounds.has(series.round),
-          sizing,
-        },
-      });
-    });
+  if (!model.format.supportsExactBracket && model.edges.length === 0) {
+    return [];
   }
 
-  // Conference label nodes, centered above round 1 columns
-  const { nodeWidth } = sizing;
-  nodes.push(
-    {
-      id: 'conf-label-west',
-      type: 'conferenceLabel',
-      position: { x: nodeWidth / 2, y: -40 },
-      data: { label: 'Western Conference' },
-      selectable: false,
-      draggable: false,
-    },
-    {
-      id: 'conf-label-east',
-      type: 'conferenceLabel',
-      position: { x: hSpacing * 6 + nodeWidth / 2, y: -40 },
-      data: { label: 'Eastern Conference' },
-      selectable: false,
-      draggable: false,
-    }
-  );
+  return model.edges.flatMap(edge => {
+    const source = seriesByKey.get(edge.sourceSeriesKey);
+    const target = seriesByKey.get(edge.targetSeriesKey);
+    if (!source || !target) return [];
+    if (!nodeIds.has(source.seriesKey) || !nodeIds.has(target.seriesKey)) return [];
+    if (!source.winnerTeamId || !revealedRounds.has(source.round)) return [];
 
-  const seriesNodes = nodes.filter(n => n.type === 'seriesNode') as Node<BracketNodeData>[];
-  const edges = createBracketEdges(seriesNodes, revealedRounds);
+    const sourceLane = nodes.find(node => node.id === source.seriesKey)?.data.lane ?? 'center';
+    const targetLane = nodes.find(node => node.id === target.seriesKey)?.data.lane ?? 'center';
+    const sourceHandle = sourceLane === 'right' ? 'src-left' : 'src-right';
+    const targetHandle = targetLane === 'right' ? 'tgt-right' : 'tgt-left';
 
-  return { nodes, edges };
+    return [{
+      id: `e-${source.seriesKey}-${target.seriesKey}`,
+      source: source.seriesKey,
+      sourceHandle,
+      target: target.seriesKey,
+      targetHandle,
+      animated: false,
+      style: {
+        stroke: '#f59e0b',
+        strokeWidth: 2,
+      },
+      type: 'bracketEdge',
+    }];
+  });
+}
+
+function createGroupLabels(
+  model: PlayoffBracketModel,
+  sizing: BracketSizing,
+  modernLayout: boolean,
+): Node[] {
+  const { hSpacing, nodeWidth, vSpacing } = sizing;
+  if (modernLayout) {
+    const finalsRound = model.format.finalsRound ?? Math.max(...model.rounds.map(item => item.round));
+    const maxConferenceRound = Math.max(1, finalsRound - 1);
+    return [
+      {
+        id: 'group-label-west',
+        type: 'conferenceLabel',
+        position: { x: nodeWidth / 2, y: -40 },
+        data: { label: 'Western Conference' },
+        selectable: false,
+        draggable: false,
+      },
+      {
+        id: 'group-label-east',
+        type: 'conferenceLabel',
+        position: { x: hSpacing * maxConferenceRound * 2 + nodeWidth / 2, y: -40 },
+        data: { label: 'Eastern Conference' },
+        selectable: false,
+        draggable: false,
+      },
+    ];
+  }
+
+  const nonFinalGroups = model.groups.filter(group => group.kind !== 'finals');
+  const maxRows = Math.max(1, ...nonFinalGroups.map(group => {
+    return Math.max(
+      1,
+      ...model.rounds.map(round => model.series.filter(item => item.bracketGroupId === group.id && item.round === round.round).length),
+    );
+  }));
+  const laneHeight = Math.max(vSpacing * (maxRows + 1), vSpacing * 2);
+
+  return nonFinalGroups.map((group, index) => ({
+    id: `group-label-${group.id}`,
+    type: 'conferenceLabel',
+    position: { x: nodeWidth / 2, y: index * laneHeight - 40 },
+    data: { label: group.label },
+    selectable: false,
+    draggable: false,
+  }));
+}
+
+export function transformToBracketData(
+  model: PlayoffBracketModel,
+  revealedRounds: Set<number>,
+  season: string,
+  sizing: BracketSizing,
+): { nodes: Node[]; edges: Edge[] } {
+  const modernLayout = isModernTwoConferenceModel(model);
+  const seriesNodes = model.series
+    .map(series => buildNode(series, model, revealedRounds, season, sizing, modernLayout))
+    .filter((node): node is Node<BracketNodeData> => node !== null);
+  const labelNodes = createGroupLabels(model, sizing, modernLayout);
+  const edges = createBracketEdges(seriesNodes, model, revealedRounds);
+
+  return { nodes: [...seriesNodes, ...labelNodes], edges };
 }

--- a/src/utils/playoffBracketModel.test.ts
+++ b/src/utils/playoffBracketModel.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import type { PlayoffBracketResponse, SeriesData } from '@/helpers/helpers';
+import { buildPlayoffBracketModel, canRevealRound } from './playoffBracketModel';
+
+const bos = { id: 1610612738, tricode: 'BOS', name: 'Celtics' };
+const nyk = { id: 1610612752, tricode: 'NYK', name: 'Knicks' };
+const lal = { id: 1610612747, tricode: 'LAL', name: 'Lakers' };
+
+function series(seriesKey: string, round: number, teams = [bos, nyk]): SeriesData {
+  return {
+    seriesKey,
+    round,
+    roundName: round === 1 ? 'First Round' : 'Conference Semifinals',
+    teams,
+    wins: { [teams[0].id]: 1 },
+    winnerTeamId: teams[0].id,
+    winnerTeamTricode: teams[0].tricode,
+    gameCount: 1,
+    games: [{
+      gameId: `${seriesKey}-1`,
+      date: `1951-04-0${round}`,
+      round,
+      roundName: round === 1 ? 'First Round' : 'Conference Semifinals',
+      homeTeam: { ...teams[0], score: 100 },
+      awayTeam: { ...teams[1], score: 90 },
+      winnerTeamId: teams[0].id,
+      winnerTeamTricode: teams[0].tricode,
+    }],
+  };
+}
+
+describe('buildPlayoffBracketModel', () => {
+  it('creates fallback metadata for legacy responses', () => {
+    const response: PlayoffBracketResponse = {
+      season: '1950-51',
+      teamGameRowCount: 4,
+      gameCount: 2,
+      seriesCount: 2,
+      series: [
+        series('R1-bos-nyk', 1),
+        series('R2-bos-lal', 2, [bos, lal]),
+      ],
+    };
+
+    const model = buildPlayoffBracketModel(response);
+
+    expect(model.fallbackMode).toBe(true);
+    expect(model.format.finalsRound).toBe(2);
+    expect(model.series[1].isFinals).toBe(true);
+    expect(model.series[1].roundName).toBe('NBA Finals');
+    expect(model.groups.some(group => group.id === 'finals')).toBe(true);
+  });
+
+  it('uses provided rounds for reveal sequencing', () => {
+    const response: PlayoffBracketResponse = {
+      season: '1983-84',
+      teamGameRowCount: 4,
+      gameCount: 2,
+      seriesCount: 2,
+      format: {
+        era: 'sixteen-team-best-of-five-first-round',
+        playoffYear: 1984,
+        finalsRound: 4,
+        bracketType: 'single-elimination',
+        supportsExactBracket: true,
+        notes: [],
+      },
+      groups: [
+        { id: 'east-conference', label: 'Eastern Conference', kind: 'conference', sortOrder: 20 },
+        { id: 'finals', label: 'NBA Finals', kind: 'finals', sortOrder: 99 },
+      ],
+      rounds: [
+        { round: 1, label: 'First Round', sortOrder: 1, defaultRevealed: true },
+        { round: 4, label: 'NBA Finals', sortOrder: 4, defaultRevealed: false },
+      ],
+      edges: [],
+      series: [
+        { ...series('R1-bos-nyk', 1), bracketGroupId: 'east-conference', bracketOrder: 0, targetWins: 3, isFinals: false },
+        { ...series('R4-bos-lal', 4, [bos, lal]), bracketGroupId: 'finals', bracketOrder: 0, targetWins: 4, isFinals: true },
+      ],
+    };
+
+    const model = buildPlayoffBracketModel(response);
+
+    expect(model.series[0].targetWins).toBe(3);
+    expect(canRevealRound(1, model.rounds, new Set())).toBe(true);
+    expect(canRevealRound(4, model.rounds, new Set())).toBe(false);
+    expect(canRevealRound(4, model.rounds, new Set([1]))).toBe(true);
+  });
+});

--- a/src/utils/playoffBracketModel.ts
+++ b/src/utils/playoffBracketModel.ts
@@ -1,0 +1,162 @@
+import type {
+  BracketEdge,
+  BracketGroup,
+  BracketGroupKind,
+  PlayoffBracketResponse,
+  PlayoffFormat,
+  RoundDefinition,
+  SeriesData,
+} from "@/helpers/helpers";
+import { getTeamConference } from "@/constants/nbaTeams";
+
+export type RenderSeries = SeriesData & {
+  bracketGroupId: string;
+  bracketGroupLabel: string;
+  bracketGroupKind: BracketGroupKind;
+  bracketOrder: number;
+  targetWins: number | null;
+  isFinals: boolean;
+};
+
+export type PlayoffBracketModel = {
+  season: string;
+  format: PlayoffFormat;
+  groups: BracketGroup[];
+  rounds: RoundDefinition[];
+  edges: BracketEdge[];
+  series: RenderSeries[];
+  fallbackMode: boolean;
+};
+
+function playoffYearFromSeason(season: string): number {
+  return Number.parseInt(season.split("-")[0], 10) + 1;
+}
+
+function makeFallbackFormat(season: string, finalsRound: number | null): PlayoffFormat {
+  return {
+    era: "unknown",
+    playoffYear: playoffYearFromSeason(season),
+    finalsRound,
+    bracketType: "single-elimination",
+    supportsExactBracket: true,
+    notes: ["Frontend generated bracket metadata from a legacy response."],
+  };
+}
+
+function fallbackGroupForSeries(series: SeriesData, isFinals: boolean): BracketGroup {
+  if (isFinals) {
+    return { id: "finals", label: "NBA Finals", kind: "finals", sortOrder: 99 };
+  }
+
+  const conf = getTeamConference(series.teams[0]?.id) ?? getTeamConference(series.teams[1]?.id);
+  if (conf === "West") {
+    return { id: "west-conference", label: "Western Conference", kind: "conference", sortOrder: 10 };
+  }
+  if (conf === "East") {
+    return { id: "east-conference", label: "Eastern Conference", kind: "conference", sortOrder: 20 };
+  }
+
+  return { id: "league", label: "League Bracket", kind: "league", sortOrder: 30 };
+}
+
+function inferFinalsRound(series: SeriesData[]): number | null {
+  if (series.length === 0) return null;
+  const byRound = new Map<number, number>();
+  for (const item of series) {
+    byRound.set(item.round, (byRound.get(item.round) ?? 0) + 1);
+  }
+  const maxRound = Math.max(...series.map(item => item.round));
+  return byRound.get(maxRound) === 1 ? maxRound : null;
+}
+
+function buildFallbackEdges(series: RenderSeries[]): BracketEdge[] {
+  return series.flatMap(source => {
+    if (!source.winnerTeamId) return [];
+    const sourceEnd = source.games.length > 0 ? source.games[source.games.length - 1].date : "";
+    const target = series
+      .filter(candidate => {
+        if (candidate.seriesKey === source.seriesKey) return false;
+        if (candidate.round <= source.round) return false;
+        if (!candidate.teams.some(team => team.id === source.winnerTeamId)) return false;
+        const targetStart = candidate.games.length > 0 ? candidate.games[0].date : "";
+        return !sourceEnd || !targetStart || targetStart >= sourceEnd;
+      })
+      .sort((a, b) => a.round - b.round || a.seriesKey.localeCompare(b.seriesKey))[0];
+
+    if (!target) return [];
+    return [{
+      sourceSeriesKey: source.seriesKey,
+      targetSeriesKey: target.seriesKey,
+      winnerTeamId: source.winnerTeamId,
+    }];
+  });
+}
+
+export function buildPlayoffBracketModel(response: PlayoffBracketResponse): PlayoffBracketModel {
+  const finalsRound = response.format?.finalsRound ?? inferFinalsRound(response.series);
+  const format = response.format ?? makeFallbackFormat(response.season, finalsRound);
+  const groupsById = new Map<string, BracketGroup>();
+  const roundLabels = new Map<number, string>();
+  const positions = new Map<string, number>();
+
+  const series = [...response.series]
+    .sort((a, b) => a.round - b.round || (a.bracketOrder ?? 0) - (b.bracketOrder ?? 0) || a.seriesKey.localeCompare(b.seriesKey))
+    .map((item): RenderSeries => {
+      const isFinals = item.isFinals ?? (finalsRound !== null && item.round === finalsRound);
+      const fallbackGroup = fallbackGroupForSeries(item, isFinals);
+      const group: BracketGroup = item.bracketGroupId
+        ? {
+            id: item.bracketGroupId,
+            label: item.bracketGroupLabel ?? fallbackGroup.label,
+            kind: item.bracketGroupKind ?? fallbackGroup.kind,
+            sortOrder: fallbackGroup.sortOrder,
+          }
+        : fallbackGroup;
+
+      groupsById.set(group.id, response.groups?.find(g => g.id === group.id) ?? group);
+      roundLabels.set(item.round, isFinals ? "NBA Finals" : item.roundName);
+
+      const positionKey = `${group.id}-${item.round}`;
+      const nextPosition = positions.get(positionKey) ?? 0;
+      positions.set(positionKey, nextPosition + 1);
+
+      return {
+        ...item,
+        bracketGroupId: group.id,
+        bracketGroupLabel: group.label,
+        bracketGroupKind: group.kind,
+        bracketOrder: item.bracketOrder ?? nextPosition,
+        targetWins: item.targetWins ?? null,
+        isFinals,
+        roundName: isFinals ? "NBA Finals" : item.roundName,
+      };
+    });
+
+  const groups = (response.groups ?? [...groupsById.values()])
+    .filter(group => series.some(item => item.bracketGroupId === group.id))
+    .sort((a, b) => a.sortOrder - b.sortOrder);
+
+  const rounds = (response.rounds ?? [...roundLabels.entries()].map(([round, label]) => ({
+    round,
+    label,
+    sortOrder: round,
+    defaultRevealed: round === Math.min(...response.series.map(item => item.round)),
+  }))).sort((a, b) => a.sortOrder - b.sortOrder);
+
+  return {
+    season: response.season,
+    format,
+    groups,
+    rounds,
+    edges: response.edges ?? buildFallbackEdges(series),
+    series,
+    fallbackMode: !response.format || !response.groups || !response.rounds || !response.edges,
+  };
+}
+
+export function canRevealRound(round: number, rounds: RoundDefinition[], revealedRounds: Set<number>): boolean {
+  const sortedRounds = [...rounds].sort((a, b) => a.sortOrder - b.sortOrder);
+  const index = sortedRounds.findIndex(item => item.round === round);
+  if (index <= 0) return true;
+  return sortedRounds.slice(0, index).every(item => revealedRounds.has(item.round));
+}

--- a/src/utils/playoffBracketModel.ts
+++ b/src/utils/playoffBracketModel.ts
@@ -157,6 +157,7 @@ export function buildPlayoffBracketModel(response: PlayoffBracketResponse): Play
 export function canRevealRound(round: number, rounds: RoundDefinition[], revealedRounds: Set<number>): boolean {
   const sortedRounds = [...rounds].sort((a, b) => a.sortOrder - b.sortOrder);
   const index = sortedRounds.findIndex(item => item.round === round);
-  if (index <= 0) return true;
+  if (index === -1) return false;
+  if (index === 0) return true;
   return sortedRounds.slice(0, index).every(item => revealedRounds.has(item.round));
 }

--- a/src/utils/seriesSlug.ts
+++ b/src/utils/seriesSlug.ts
@@ -7,6 +7,13 @@ const ROUND_SLUGS: Record<number, string> = {
   3: 'final',
 };
 
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
 function getSeriesConference(series: SeriesData): 'east' | 'west' {
   const conf = getTeamConference(series.teams[0].id) ?? getTeamConference(series.teams[1].id);
   if (!conf) {
@@ -28,7 +35,15 @@ export function yearToSeason(year: string): string {
 }
 
 export function buildSeriesSlug(series: SeriesData, allSeries: SeriesData[]): string {
-  if (series.round === 4) return 'the-finals';
+  if (series.isFinals || series.round === 4) return 'the-finals';
+
+  if (series.bracketGroupId) {
+    const roundSlug = ROUND_SLUGS[series.round] ?? `round-${series.round}`;
+    const order = (series.bracketOrder ?? allSeries.filter(s =>
+      s.round === series.round && s.bracketGroupId === series.bracketGroupId
+    ).findIndex(s => s.seriesKey === series.seriesKey)) + 1;
+    return `${slugify(series.bracketGroupId)}-${roundSlug}-${order}`;
+  }
 
   const conf = getSeriesConference(series);
   const roundSlug = ROUND_SLUGS[series.round];
@@ -54,7 +69,13 @@ export function buildSeriesSlug(series: SeriesData, allSeries: SeriesData[]): st
 export function buildSlugMap(allSeries: SeriesData[]): Map<string, SeriesData> {
   const groups = new Map<string, SeriesData[]>();
   for (const s of allSeries) {
-    if (s.round === 4) continue;
+    if (s.isFinals || s.round === 4) continue;
+    if (s.bracketGroupId) {
+      const key = `${s.round}-${s.bracketGroupId}`;
+      if (!groups.has(key)) groups.set(key, []);
+      groups.get(key)!.push(s);
+      continue;
+    }
     const conf = getSeriesConference(s);
     const key = `${s.round}-${conf}`;
     if (!groups.has(key)) groups.set(key, []);
@@ -63,10 +84,21 @@ export function buildSlugMap(allSeries: SeriesData[]): Map<string, SeriesData> {
 
   const map = new Map<string, SeriesData>();
   for (const s of allSeries) {
-    if (s.round === 4) {
+    if (s.isFinals || s.round === 4) {
       map.set('the-finals', s);
+      map.set('finals', s);
       continue;
     }
+
+    if (s.bracketGroupId) {
+      const roundSlug = ROUND_SLUGS[s.round] ?? `round-${s.round}`;
+      const sameGroup = groups.get(`${s.round}-${s.bracketGroupId}`) ?? [];
+      const matchupNum = (s.bracketOrder ?? sameGroup.findIndex(s2 => s2.seriesKey === s.seriesKey)) + 1;
+      map.set(`${slugify(s.bracketGroupId)}-${roundSlug}-${matchupNum}`, s);
+      map.set(`series-${slugify(s.seriesKey)}`, s);
+      continue;
+    }
+
     const conf = getSeriesConference(s);
     const roundSlug = ROUND_SLUGS[s.round];
     if (s.round === 3) {

--- a/src/utils/seriesSlug.ts
+++ b/src/utils/seriesSlug.ts
@@ -39,9 +39,16 @@ export function buildSeriesSlug(series: SeriesData, allSeries: SeriesData[]): st
 
   if (series.bracketGroupId) {
     const roundSlug = ROUND_SLUGS[series.round] ?? `round-${series.round}`;
-    const order = (series.bracketOrder ?? allSeries.filter(s =>
+    const sameGroup = allSeries.filter(s =>
       s.round === series.round && s.bracketGroupId === series.bracketGroupId
-    ).findIndex(s => s.seriesKey === series.seriesKey)) + 1;
+    );
+    const fallbackOrder = sameGroup.findIndex(s => s.seriesKey === series.seriesKey);
+    if (fallbackOrder === -1) {
+      throw new Error(
+        `buildSeriesSlug: data-contract violation, series not found in allSeries matching round and bracketGroupId (seriesKey=${series.seriesKey}, round=${series.round}, bracketGroupId=${series.bracketGroupId})`
+      );
+    }
+    const order = (series.bracketOrder ?? fallbackOrder) + 1;
     return `${slugify(series.bracketGroupId)}-${roundSlug}-${order}`;
   }
 
@@ -93,7 +100,13 @@ export function buildSlugMap(allSeries: SeriesData[]): Map<string, SeriesData> {
     if (s.bracketGroupId) {
       const roundSlug = ROUND_SLUGS[s.round] ?? `round-${s.round}`;
       const sameGroup = groups.get(`${s.round}-${s.bracketGroupId}`) ?? [];
-      const matchupNum = (s.bracketOrder ?? sameGroup.findIndex(s2 => s2.seriesKey === s.seriesKey)) + 1;
+      const fallbackOrder = sameGroup.findIndex(s2 => s2.seriesKey === s.seriesKey);
+      if (fallbackOrder === -1) {
+        throw new Error(
+          `buildSlugMap: data-contract violation, series not found in allSeries matching round and bracketGroupId (seriesKey=${s.seriesKey}, round=${s.round}, bracketGroupId=${s.bracketGroupId})`
+        );
+      }
+      const matchupNum = (s.bracketOrder ?? fallbackOrder) + 1;
       map.set(`${slugify(s.bracketGroupId)}-${roundSlug}-${matchupNum}`, s);
       map.set(`series-${slugify(s.seriesKey)}`, s);
       continue;


### PR DESCRIPTION
closes #165

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Playoff bracket now displays "Best of N" series format information.
  * Extended historical playoff season support back to 1951.
  * Enhanced bracket visualization with advancement edges and round definitions.

* **Improvements**
  * Mobile bracket layout reorganized to support varied playoff formats more flexibly.
  * Bracket metadata enrichment for better structure and organization across different eras.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->