### PR TITLE
Fix series data

### DIFF
--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -1,7 +1,7 @@
 import json
 import time
 from collections import defaultdict
-from datetime import date
+from datetime import date, timedelta
 from pathlib import Path
 
 from fastapi import HTTPException
@@ -22,8 +22,9 @@ with open(_CONFERENCES_JSON) as _f:
 EAST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["east"])
 WEST_TEAM_IDS: frozenset[int] = frozenset(CONFERENCES["west"])
 
-# season -> (fetched_at_monotonic, df)
+# (season, source) -> (fetched_at_monotonic, df)
 _df_cache: dict = {}
+_CURRENT_SEASON_TTL_SECONDS = 5 * 60
 
 # game_id -> {team_id: points}, cached so each defensive repair is only fetched once.
 _linescore_cache: dict = {}
@@ -165,9 +166,14 @@ def get_target_wins(playoff_year: int, round_number: int, is_finals: bool):
     return 4
 
 
-def should_use_active_playoff_source(season: str, today: date | None = None) -> bool:
+def get_current_season(today: date | None = None) -> str:
     today = today or date.today()
-    current_season = get_nba_season(today.year, today.month)
+    return get_nba_season(today.year, today.month)
+
+
+def should_use_active_playoff_source(season: str, today: date | None = None) -> bool:
+    current_season = get_current_season(today) if today else get_current_season()
+    today = today or date.today()
 
     return season == current_season and today.month in {4, 5, 6}
 
@@ -184,7 +190,14 @@ def fetch_playoff_team_games_df(season: str, today: date | None = None):
     cache_key = (season, source)
 
     if cache_key in _df_cache:
-        return _df_cache[cache_key]
+        fetched_at, cached_df = _df_cache[cache_key]
+        current_season = get_current_season(today) if today else get_current_season()
+        if season != current_season:
+            return cached_df
+
+        age = time.monotonic() - fetched_at
+        if age < _CURRENT_SEASON_TTL_SECONDS:
+            return cached_df
 
     try:
         if source == "league_game_finder":
@@ -206,7 +219,7 @@ def fetch_playoff_team_games_df(season: str, today: date | None = None):
             detail=f"NBA Stats API unavailable: {e}",
         ) from e
 
-    _df_cache[cache_key] = df
+    _df_cache[cache_key] = (time.monotonic(), df)
     return df
 
 
@@ -466,7 +479,7 @@ def infer_bracket_position_from_game_id(game_id: str):
     Returns None if the game ID is not a modern format (old sequential IDs
     like 0040000001 do not encode series position and should not use this).
     """
-    # Only extract position for modern game IDs where round is encoded
+    # Only extract position for game IDs where round is encoded.
     if infer_round_from_game_id(game_id) is None:
         return None
 
@@ -966,6 +979,201 @@ def sort_by_bracket_progression(playoff_series, use_game_id_position):
     return sorted(playoff_series, key=_sort_key)
 
 
+def get_game_team_id_pair(game):
+    return tuple(
+        sorted(
+            [
+                game["homeTeam"]["id"],
+                game["awayTeam"]["id"],
+            ]
+        )
+    )
+
+
+def get_series_team_id_pair(series):
+    return tuple(sorted(team["id"] for team in series.get("teams", [])))
+
+
+def series_wins_for_games(games):
+    wins = defaultdict(int)
+
+    for game in games:
+        winner_id = game.get("winnerTeamId")
+        if winner_id is not None:
+            wins[winner_id] += 1
+
+    return dict(wins)
+
+
+def get_series_target_wins_for_round(season, round_number, is_finals):
+    playoff_year = get_playoff_end_year(season)
+    return get_target_wins(playoff_year, round_number, is_finals)
+
+
+def _date_from_iso(date_value):
+    return date.fromisoformat(date_value)
+
+
+def _series_start_date(series):
+    return get_series_dates(series)[0]
+
+
+def is_valid_orphan_merge(season, orphan_series, target_series, all_series):
+    if get_series_team_id_pair(orphan_series) != get_series_team_id_pair(target_series):
+        return False
+
+    if orphan_series["gameCount"] != 1:
+        return False
+
+    if target_series["gameCount"] < 1:
+        return False
+
+    if target_series["round"] <= orphan_series["round"]:
+        return False
+
+    if target_series["round"] - orphan_series["round"] > 2:
+        return False
+
+    orphan_games = orphan_series.get("games", [])
+    target_games = target_series.get("games", [])
+    if len(orphan_games) != 1 or not target_games:
+        return False
+
+    orphan_game = orphan_games[0]
+    team_pair = set(get_series_team_id_pair(target_series))
+    if orphan_game.get("winnerTeamId") not in team_pair:
+        return False
+
+    target_start, target_end = get_series_dates(target_series)
+    if not target_start or not target_end:
+        return False
+
+    orphan_date = _date_from_iso(orphan_game["date"])
+    start_date = _date_from_iso(target_start)
+    end_date = _date_from_iso(target_end)
+    tolerance = timedelta(days=3)
+
+    if orphan_date < start_date - tolerance or orphan_date > end_date + tolerance:
+        return False
+
+    initial_finals_round = get_finals_round(all_series)
+    is_target_finals = (
+        initial_finals_round is not None
+        and target_series["round"] == initial_finals_round
+    )
+    target_wins = get_series_target_wins_for_round(
+        season,
+        target_series["round"],
+        is_target_finals,
+    )
+
+    if target_wins is None:
+        return False
+
+    merged_games = orphan_games + target_games
+    merged_count = len(merged_games)
+    if merged_count > (2 * target_wins - 1):
+        return False
+
+    merged_wins = series_wins_for_games(merged_games)
+    if not merged_wins or max(merged_wins.values()) != target_wins:
+        return False
+
+    win_values = list(merged_wins.values())
+    if len(win_values) == 2 and win_values[0] == win_values[1]:
+        return False
+
+    return True
+
+
+def _orphan_target_sort_key(orphan_series, target_series):
+    orphan_start = _date_from_iso(_series_start_date(orphan_series))
+    target_start = _date_from_iso(_series_start_date(target_series))
+    date_distance = abs((target_start - orphan_start).days)
+
+    return (
+        target_series["round"],
+        date_distance,
+        target_series["seriesKey"],
+    )
+
+
+def find_orphan_series_merges(season, playoff_series):
+    by_team_pair = defaultdict(list)
+
+    for series in playoff_series:
+        by_team_pair[get_series_team_id_pair(series)].append(series)
+
+    orphan_round_updates = {}
+
+    for same_pair_series in by_team_pair.values():
+        if len(same_pair_series) < 2:
+            continue
+
+        ordered_series = sorted(
+            same_pair_series,
+            key=lambda series: (
+                series["round"],
+                _series_start_date(series),
+                series["seriesKey"],
+            ),
+        )
+
+        for orphan_series in ordered_series:
+            if orphan_series["gameCount"] != 1:
+                continue
+
+            valid_targets = [
+                target_series
+                for target_series in ordered_series
+                if is_valid_orphan_merge(
+                    season,
+                    orphan_series,
+                    target_series,
+                    playoff_series,
+                )
+            ]
+
+            if not valid_targets:
+                continue
+
+            target_series = min(
+                valid_targets,
+                key=lambda series: _orphan_target_sort_key(orphan_series, series),
+            )
+            orphan_round_updates[orphan_series["seriesKey"]] = target_series["round"]
+
+    return orphan_round_updates
+
+
+def reconcile_duplicate_matchup_rounds(season, games):
+    playoff_series = derive_playoff_series(games)
+    orphan_round_updates = find_orphan_series_merges(season, playoff_series)
+
+    if not orphan_round_updates:
+        return games
+
+    reconciled_games = []
+
+    for game in games:
+        series_key = get_series_key(game)
+
+        if series_key not in orphan_round_updates:
+            reconciled_games.append(game)
+            continue
+
+        round_num = orphan_round_updates[series_key]
+        game_copy = game.copy()
+        game_copy["round"] = round_num
+        game_copy["roundName"] = get_round_name(round_num)
+        reconciled_games.append(game_copy)
+
+    return sorted(
+        reconciled_games,
+        key=lambda game: (game["date"], game["gameId"]),
+    )
+
+
 def derive_playoff_series(games):
     series_map = defaultdict(
         lambda: {
@@ -1044,6 +1252,7 @@ def get_normalized_playoff_games(season: str):
     games = normalize_playoff_games(df)
     games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
+    games = reconcile_duplicate_matchup_rounds(season, games)
 
     return {
         "season": season,
@@ -1058,6 +1267,7 @@ def get_playoff_series(season: str):
     games = normalize_playoff_games(df)
     games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
+    games = reconcile_duplicate_matchup_rounds(season, games)
     playoff_series = derive_playoff_series(games)
     bracket = enrich_playoff_bracket_response(season, playoff_series)
 
@@ -1079,6 +1289,7 @@ def get_playoff_games_and_series(season: str):
     games = normalize_playoff_games(df)
     games = correct_game_scores(games)
     games = apply_rounds_to_games(games)
+    games = reconcile_duplicate_matchup_rounds(season, games)
     playoff_series = derive_playoff_series(games)
     bracket = enrich_playoff_bracket_response(season, playoff_series)
 

--- a/server/tests/test_playoffs_cache.py
+++ b/server/tests/test_playoffs_cache.py
@@ -15,14 +15,19 @@ from server.services import playoffs
 def _patch_finder(monkeypatch):
     calls = {"n": 0}
 
-    class _FakeFinder:
+    class _FakePlayoffClient:
         def __init__(self, *a, **k):
             calls["n"] += 1
 
         def get_data_frames(self):
             return [pd.DataFrame()]
 
-    monkeypatch.setattr(playoffs.leaguegamefinder, "LeagueGameFinder", _FakeFinder)
+    monkeypatch.setattr(
+        playoffs.leaguegamefinder,
+        "LeagueGameFinder",
+        _FakePlayoffClient,
+    )
+    monkeypatch.setattr(playoffs, "LeagueGameLog", _FakePlayoffClient)
     monkeypatch.setattr(playoffs, "_df_cache", {})
     return calls
 

--- a/server/tests/test_playoffs_duplicate_matchup_reconciliation.py
+++ b/server/tests/test_playoffs_duplicate_matchup_reconciliation.py
@@ -1,0 +1,277 @@
+"""Regression tests for duplicate-matchup playoff series reconciliation."""
+
+from collections import Counter
+
+import pandas as pd
+
+from server.services import playoffs
+
+
+BOS = 1610612738
+LAL = 1610612747
+NYK = 1610612752
+PHL = 1610612755
+ROC = 1610612758
+
+
+def _team_row(game_id, date, matchup, abbr, team_id, wl, pts):
+    return {
+        "GAME_ID": game_id,
+        "GAME_DATE": date,
+        "MATCHUP": matchup,
+        "TEAM_ID": team_id,
+        "TEAM_ABBREVIATION": abbr,
+        "TEAM_NAME": abbr,
+        "WL": wl,
+        "PTS": pts,
+    }
+
+
+def _add_game(rows, game_id, date, away, home, winner_abbr):
+    away_abbr, away_id, away_pts = away
+    home_abbr, home_id, home_pts = home
+
+    rows.append(
+        _team_row(
+            game_id,
+            date,
+            f"{home_abbr} vs. {away_abbr}",
+            home_abbr,
+            home_id,
+            "W" if winner_abbr == home_abbr else "L",
+            home_pts,
+        )
+    )
+    rows.append(
+        _team_row(
+            game_id,
+            date,
+            f"{away_abbr} @ {home_abbr}",
+            away_abbr,
+            away_id,
+            "W" if winner_abbr == away_abbr else "L",
+            away_pts,
+        )
+    )
+
+
+def _series_for_rows(season, rows):
+    normalized = playoffs.normalize_playoff_games(pd.DataFrame(rows))
+    with_rounds = playoffs.apply_rounds_to_games(normalized)
+    reconciled = playoffs.reconcile_duplicate_matchup_rounds(season, with_rounds)
+    series = playoffs.derive_playoff_series(reconciled)
+    bracket = playoffs.enrich_playoff_bracket_response(season, series)
+    return bracket["series"]
+
+
+def _series_for_pair(series, *team_ids):
+    pair = set(team_ids)
+    return [
+        item
+        for item in series
+        if {team["id"] for team in item["teams"]} == pair
+    ]
+
+
+def _assert_no_duplicate_pairs(series):
+    pairs = Counter(
+        tuple(sorted(team["id"] for team in item["teams"]))
+        for item in series
+    )
+    assert all(count == 1 for count in pairs.values())
+
+
+def _assert_no_completed_finals_tie(series):
+    for item in series:
+        if not item.get("isFinals"):
+            continue
+
+        wins = list(item["wins"].values())
+        assert len(wins) != 2 or wins[0] != wins[1]
+
+
+def _assert_series_reaches_target(series):
+    for item in series:
+        target_wins = item.get("targetWins")
+        if target_wins is None:
+            continue
+
+        assert max(item["wins"].values()) == target_wins
+
+
+def _1951_finals_rows():
+    rows = []
+    games = [
+        ("0045000301", "1951-04-07", ("NYK", NYK, 65), ("ROC", ROC, 92), "ROC"),
+        ("0045000412", "1951-04-08", ("NYK", NYK, 84), ("ROC", ROC, 99), "ROC"),
+        ("0045000413", "1951-04-11", ("ROC", ROC, 78), ("NYK", NYK, 71), "ROC"),
+        ("0045000414", "1951-04-13", ("ROC", ROC, 73), ("NYK", NYK, 79), "NYK"),
+        ("0045000415", "1951-04-15", ("NYK", NYK, 92), ("ROC", ROC, 89), "NYK"),
+        ("0045000416", "1951-04-18", ("ROC", ROC, 73), ("NYK", NYK, 80), "NYK"),
+        ("0045000417", "1951-04-21", ("NYK", NYK, 75), ("ROC", ROC, 79), "ROC"),
+    ]
+
+    for game in games:
+        _add_game(rows, *game)
+
+    return rows
+
+
+def _1965_finals_rows():
+    rows = []
+    games = [
+        ("0046400301", "1965-04-18", ("LAL", LAL, 110), ("BOS", BOS, 142), "BOS"),
+        ("0046400412", "1965-04-19", ("LAL", LAL, 123), ("BOS", BOS, 129), "BOS"),
+        ("0046400413", "1965-04-21", ("BOS", BOS, 105), ("LAL", LAL, 126), "LAL"),
+        ("0046400414", "1965-04-23", ("BOS", BOS, 112), ("LAL", LAL, 99), "BOS"),
+        ("0046400415", "1965-04-25", ("LAL", LAL, 96), ("BOS", BOS, 129), "BOS"),
+    ]
+
+    for game in games:
+        _add_game(rows, *game)
+
+    return rows
+
+
+def _1967_eastern_finals_rows():
+    rows = []
+    games = [
+        ("0046600321", "1967-03-31", ("BOS", BOS, 113), ("PHL", PHL, 127), "PHL"),
+        ("0046600322", "1967-04-02", ("PHL", PHL, 107), ("BOS", BOS, 102), "PHL"),
+        ("0046600323", "1967-04-05", ("BOS", BOS, 104), ("PHL", PHL, 115), "PHL"),
+        ("0046600204", "1967-04-09", ("PHL", PHL, 117), ("BOS", BOS, 121), "BOS"),
+        ("0046600325", "1967-04-11", ("BOS", BOS, 116), ("PHL", PHL, 140), "PHL"),
+    ]
+
+    for game in games:
+        _add_game(rows, *game)
+
+    return rows
+
+
+def test_1951_duplicate_matchup_orphan_merges_into_finals():
+    series = _series_for_rows("1950-51", _1951_finals_rows())
+    finals = _series_for_pair(series, ROC, NYK)
+
+    assert len(finals) == 1
+    assert finals[0]["round"] == 4
+    assert finals[0]["gameCount"] == 7
+    assert finals[0]["wins"][ROC] == 4
+    assert finals[0]["wins"][NYK] == 3
+    assert finals[0]["winnerTeamId"] == ROC
+    assert "1951-04-07" in [game["date"] for game in finals[0]["games"]]
+
+
+def test_1965_duplicate_matchup_orphan_merges_into_finals():
+    series = _series_for_rows("1964-65", _1965_finals_rows())
+    finals = _series_for_pair(series, BOS, LAL)
+
+    assert len(finals) == 1
+    assert finals[0]["round"] == 4
+    assert finals[0]["gameCount"] == 5
+    assert finals[0]["wins"][BOS] == 4
+    assert finals[0]["wins"][LAL] == 1
+    assert finals[0]["winnerTeamId"] == BOS
+    assert "1965-04-18" in [game["date"] for game in finals[0]["games"]]
+
+
+def test_1967_duplicate_matchup_orphan_merges_into_division_finals():
+    series = _series_for_rows("1966-67", _1967_eastern_finals_rows())
+    eastern_finals = _series_for_pair(series, PHL, BOS)
+
+    assert len(eastern_finals) == 1
+    assert eastern_finals[0]["round"] == 3
+    assert eastern_finals[0]["gameCount"] == 5
+    assert eastern_finals[0]["wins"][PHL] == 4
+    assert eastern_finals[0]["wins"][BOS] == 1
+    assert eastern_finals[0]["winnerTeamId"] == PHL
+    assert "1967-04-09" in [game["date"] for game in eastern_finals[0]["games"]]
+
+
+def test_corrected_historical_series_invariants():
+    cases = [
+        ("1950-51", _1951_finals_rows()),
+        ("1964-65", _1965_finals_rows()),
+        ("1966-67", _1967_eastern_finals_rows()),
+    ]
+
+    for season, rows in cases:
+        series = _series_for_rows(season, rows)
+
+        _assert_no_duplicate_pairs(series)
+        _assert_no_completed_finals_tie(series)
+        _assert_series_reaches_target(series)
+
+
+def test_reconciliation_does_not_merge_duplicate_pair_when_orphan_is_not_one_game():
+    rows = []
+    games = [
+        ("0046400301", "1965-04-18", ("LAL", LAL, 110), ("BOS", BOS, 142), "BOS"),
+        ("0046400302", "1965-04-19", ("BOS", BOS, 100), ("LAL", LAL, 105), "LAL"),
+        ("0046400413", "1965-04-21", ("BOS", BOS, 105), ("LAL", LAL, 126), "LAL"),
+        ("0046400414", "1965-04-23", ("BOS", BOS, 112), ("LAL", LAL, 99), "BOS"),
+        ("0046400415", "1965-04-25", ("LAL", LAL, 96), ("BOS", BOS, 129), "BOS"),
+    ]
+    for game in games:
+        _add_game(rows, *game)
+
+    series = _series_for_rows("1964-65", rows)
+    lakers_celtics = _series_for_pair(series, BOS, LAL)
+
+    assert len(lakers_celtics) == 2
+
+
+def test_reconciliation_does_not_merge_when_combined_wins_do_not_reach_target():
+    rows = []
+    games = [
+        ("0046400301", "1965-04-18", ("LAL", LAL, 110), ("BOS", BOS, 142), "BOS"),
+        ("0046400412", "1965-04-19", ("LAL", LAL, 123), ("BOS", BOS, 129), "BOS"),
+        ("0046400413", "1965-04-21", ("BOS", BOS, 105), ("LAL", LAL, 126), "LAL"),
+        ("0046400414", "1965-04-23", ("BOS", BOS, 112), ("LAL", LAL, 99), "BOS"),
+    ]
+    for game in games:
+        _add_game(rows, *game)
+
+    series = _series_for_rows("1964-65", rows)
+    lakers_celtics = _series_for_pair(series, BOS, LAL)
+
+    assert len(lakers_celtics) == 2
+
+
+def test_reconciliation_does_not_merge_when_combined_games_exceed_max():
+    rows = []
+    games = [
+        ("0046400301", "1965-04-18", ("LAL", LAL, 110), ("BOS", BOS, 142), "BOS"),
+        ("0046400412", "1965-04-19", ("LAL", LAL, 123), ("BOS", BOS, 129), "BOS"),
+        ("0046400413", "1965-04-21", ("BOS", BOS, 105), ("LAL", LAL, 126), "LAL"),
+        ("0046400414", "1965-04-23", ("BOS", BOS, 112), ("LAL", LAL, 99), "BOS"),
+        ("0046400415", "1965-04-25", ("LAL", LAL, 96), ("BOS", BOS, 129), "BOS"),
+        ("0046400416", "1965-04-27", ("BOS", BOS, 95), ("LAL", LAL, 101), "LAL"),
+        ("0046400417", "1965-04-29", ("LAL", LAL, 98), ("BOS", BOS, 104), "BOS"),
+        ("0046400418", "1965-05-01", ("BOS", BOS, 99), ("LAL", LAL, 103), "LAL"),
+    ]
+    for game in games:
+        _add_game(rows, *game)
+
+    series = _series_for_rows("1964-65", rows)
+    lakers_celtics = _series_for_pair(series, BOS, LAL)
+
+    assert len(lakers_celtics) == 2
+
+
+def test_reconciliation_does_not_merge_legitimate_rematch_without_valid_completion():
+    rows = []
+    games = [
+        ("0046600204", "1967-04-09", ("PHL", PHL, 117), ("BOS", BOS, 121), "BOS"),
+        ("0046600321", "1967-04-20", ("BOS", BOS, 113), ("PHL", PHL, 127), "PHL"),
+        ("0046600322", "1967-04-22", ("PHL", PHL, 107), ("BOS", BOS, 102), "PHL"),
+        ("0046600323", "1967-04-25", ("BOS", BOS, 104), ("PHL", PHL, 115), "PHL"),
+        ("0046600325", "1967-05-10", ("BOS", BOS, 116), ("PHL", PHL, 140), "PHL"),
+    ]
+    for game in games:
+        _add_game(rows, *game)
+
+    series = _series_for_rows("1966-67", rows)
+    celtics_sixers = _series_for_pair(series, BOS, PHL)
+
+    assert len(celtics_sixers) == 2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved playoff data reconciliation to accurately handle duplicate or orphan matchup rounds. Series grouping, round assignments, and bracket positions are now corrected for affected historical data.

* **Tests**
  * Added comprehensive regression tests validating playoff series reconciliation behavior across multiple historical seasons and edge cases to prevent future regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->