### PR TITLE
add white border for hard to see logos in dark mode

### DIFF
--- a/src/components/BracketSeriesNode.tsx
+++ b/src/components/BracketSeriesNode.tsx
@@ -25,7 +25,7 @@ function BracketSeriesNode({ data }: BracketSeriesNodeProps) {
         className={`flex items-center justify-between ${sizing.rowGapClass} ${sizing.rowPadClass} bg-gray-900 ${cornerClass} ${isTopRow ? 'border-b-2 border-gray-700' : ''}`}
       >
         <div className={`flex items-center ${sizing.rowGapClass} min-w-0`}>
-          <div className={`bg-white rounded ${sizing.logoPadClass} flex-shrink-0`}>
+          <div className={`flex-shrink-0 ${sizing.logoPadClass}`}>
             <TeamLogos teamName={team.tricode} teamId={team.id} size={sizing.logoSize} tricode={team.tricode} />
           </div>
           <span

--- a/src/components/MobileSeriesCard.tsx
+++ b/src/components/MobileSeriesCard.tsx
@@ -30,7 +30,7 @@ function MobileSeriesCard({ series, allSeries, season, isRevealed }: MobileSerie
       }`}
     >
       <div className="flex items-center gap-2 min-w-0">
-        <div className="bg-white rounded p-0.5 flex-shrink-0">
+        <div className="p-0.5 flex-shrink-0">
           <TeamLogos teamName={team.tricode} teamId={team.id} size={28} tricode={team.tricode} />
         </div>
         <span

--- a/src/components/TeamLogos.tsx
+++ b/src/components/TeamLogos.tsx
@@ -1,6 +1,19 @@
 import { placeholderTeamLogoUrl } from "@/helpers/helpers";
 import { HISTORICAL_TEAM_LOGOS } from "@/constants/historicalTeamLogos";
 
+const add_contrast_to_logos = new Set<number | string>([
+  1610612751, // BKN Nets
+  1610612741, // CHI Bulls
+  1610612757, // POR Trail Blazers
+  1610612759, // SAS Spurs
+  "GOS", // Golden State Warriors
+  "SFW", // San Francisco Warriors
+  "PHW", // Philadelphia Warriors
+  "HUS", // Toronto Huskies
+  "TCB", // Tri-Cities Blackhawks
+  "KCK", // Kansas City Kings
+]);
+
 interface TeamLogoProps {
   teamName?: string;
   teamId: number;
@@ -9,35 +22,48 @@ interface TeamLogoProps {
 }
 
 const TeamLogos = ({ teamName, teamId, size, tricode }: TeamLogoProps) => {
-  const historicalLogoUrl = tricode
-    ? HISTORICAL_TEAM_LOGOS[tricode.toUpperCase()]
+  const normalizedTricode = tricode?.trim().toUpperCase();
+  const historicalLogoUrl = normalizedTricode
+    ? HISTORICAL_TEAM_LOGOS[normalizedTricode]
     : undefined;
   const logoUrl = historicalLogoUrl
     ?? `https://cdn.nba.com/logos/nba/${teamId}/global/L/logo.svg`;
+  const needsContrastTile = add_contrast_to_logos.has(teamId)
+    || (normalizedTricode ? add_contrast_to_logos.has(normalizedTricode) : false);
+
+  const logoImage = teamId ? (
+    <img
+      src={logoUrl}
+      alt={`${teamName} logo`}
+      width={size}
+      height={size}
+      className="h-full w-full"
+      style={{ objectFit: 'contain' }}
+      onError={(e) => {
+        e.currentTarget.src = placeholderTeamLogoUrl;
+        e.currentTarget.onerror = null;
+      }}
+    />
+  ) : (
+    <img
+      src={placeholderTeamLogoUrl}
+      alt="Placeholder team logo"
+      width={size}
+      height={size}
+      className="h-full w-full"
+      style={{ objectFit: 'contain' }}
+    />
+  );
 
   return (
     <>
       <figure className="flex items-center justify-center flex-shrink-0" style={{ width: size, height: size }}>
-        {teamId ? (
-          <img
-            src={logoUrl}
-            alt={`${teamName} logo`}
-            width={size}
-            height={size}
-            style={{ objectFit: 'contain' }}
-            onError={(e) => {
-              e.currentTarget.src = placeholderTeamLogoUrl;
-              e.currentTarget.onerror = null;
-            }}
-          />
+        {needsContrastTile ? (
+          <span className="flex h-full w-full items-center justify-center rounded bg-white p-0.5">
+            {logoImage}
+          </span>
         ) : (
-          <img
-            src={placeholderTeamLogoUrl}
-            alt="Placeholder team logo"
-            width={size}
-            height={size}
-            style={{ objectFit: 'contain' }}
-          />
+          logoImage
         )}
       </figure>
       <figcaption className="sr-only">{teamName} logo</figcaption>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Updated logo display styling in bracket series and mobile card views with refined layout properties for improved visual consistency
  * Team logos now render with dynamic contrast backgrounds when needed for better visibility

* **Bug Fixes**
  * Enhanced team identifier normalization to ensure consistent and reliable logo lookups

<!-- end of auto-generated comment: release notes by coderabbit.ai -->