### PR TITLE
make boxscores from 1946 and onward available

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## About
 
-Find the scores and stats of your favorite NBA team! Scorez can be accessed for games from the 1946/47 season, and after. Boxscores are only available for games from the 2019/20 season, and after. Explore NBA playoff brackets going back to the 1946/47 season, with round-by-round reveal controls and detailed series views.
+Find the scores and stats of your favorite NBA team! Scorez, boxscores, and playoff data go back to the 1946/47 season.
 
 ## Screenshots
 
@@ -64,7 +64,7 @@ Navigate to the [Playoffs](https://nba-scorez.onrender.com/playoffs) page to exp
 - Select any season with the year picker
 - Toggle results round by round to avoid spoilers
 - Click any series to see a game-by-game breakdown with scores, dates, and links to box scores
-- Watch links are available for seasons from 2012/13 onward
+- Watch links are available for seasons from 2012/13 onward, depending on League Pass availability
 - On desktop, the bracket is rendered with [React Flow](https://reactflow.dev/)
 
 <div align='right'>

--- a/server/main.py
+++ b/server/main.py
@@ -67,6 +67,11 @@ def get_v3_scoreboard(
 def get_game_boxscore(game_id: str):
     try:
         return {"game": fetch_boxscoretraditional(game_id)}
+    except ValueError as e:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Boxscore unavailable for game {game_id}: {str(e)}",
+        )
     except Exception as e:
         print(f"Error fetching boxscore for {game_id}: {e}")
         raise HTTPException(

--- a/server/main.py
+++ b/server/main.py
@@ -1,16 +1,18 @@
 from fastapi import FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 from nba_api.stats.endpoints import (
-    boxscoresummaryv2,
-    boxscoretraditionalv3,
     ScheduleLeagueV2,
     scoreboardv2,
     scoreboardv3,
 )
 from datetime import datetime
 from .utils.season import get_nba_season
+from .utils.boxscore_availability import (
+    is_boxscore_available_metadata,
+)
 from .services.nba_schedule import get_game_days_in_month
 from .models.schemas import GameDaysResponse
+from .services.game_summary import fetch_boxscoretraditional, fetch_game_summary
 from .services.playoffs import (
     get_normalized_playoff_games,
     fetch_playoff_team_games_df,
@@ -29,6 +31,17 @@ app.add_middleware(
 )
 
 
+def add_boxscore_availability_to_scoreboard(scoreboard, target_date):
+    for game in scoreboard.get("games", []):
+        game_date = str(game.get("gameTimeUTC") or target_date)[:10]
+        game["boxscoreAvailable"] = is_boxscore_available_metadata(
+            game.get("gameId"),
+            game_date,
+            game.get("gameStatus"),
+        )
+    return scoreboard
+
+
 @app.get("/")
 def get_v3_scoreboard(
     date: str = Query(
@@ -41,7 +54,9 @@ def get_v3_scoreboard(
         target_date = date if date else datetime.now().strftime("%Y-%m-%d")
         board = scoreboardv3.ScoreboardV3(game_date=target_date, league_id="00")
         full_data = board.get_dict()
-        return full_data["scoreboard"]
+        return add_boxscore_availability_to_scoreboard(
+            full_data["scoreboard"], target_date
+        )
     except Exception as e:
         raise HTTPException(
             status_code=500, detail=f"Failed to fetch ScoreboardV3: {str(e)}"
@@ -51,16 +66,7 @@ def get_v3_scoreboard(
 @app.get("/games/{game_id}/boxscore")
 def get_game_boxscore(game_id: str):
     try:
-        box = boxscoretraditionalv3.BoxScoreTraditionalV3(
-            game_id=game_id,
-            range_type=0,
-            start_period=0,
-            end_period=10,
-            start_range=0,
-            end_range=0,
-        )
-        data = box.get_dict()
-        return {"game": data["boxScoreTraditional"]}
+        return {"game": fetch_boxscoretraditional(game_id)}
     except Exception as e:
         print(f"Error fetching boxscore for {game_id}: {e}")
         raise HTTPException(
@@ -71,143 +77,7 @@ def get_game_boxscore(game_id: str):
 @app.get("/gamesummary/{game_id}")
 def get_game_summary(game_id: str):
     try:
-        summary = boxscoresummaryv2.BoxScoreSummaryV2(game_id=game_id)
-        game_summary_df = summary.game_summary.get_data_frame()
-        if game_summary_df.empty:
-            raise HTTPException(status_code=404, detail="Game not found")
-        game_meta = game_summary_df.iloc[0]
-        home_team_id = game_meta["HOME_TEAM_ID"]
-        visitor_team_id = game_meta["VISITOR_TEAM_ID"]
-        live_period = game_meta["LIVE_PERIOD"]
-        game_status_id = game_meta["GAME_STATUS_ID"]
-        fallback_linescore = summary.line_score.get_data_frame()
-        game_linescore = fallback_linescore if not fallback_linescore.empty else None
-        def make_scheduled_response(home_id, away_id):
-            return {
-                "homeTeam": {
-                    "teamId": int(home_id),
-                    "teamTricode": "",
-                    "teamName": "",
-                    "score": "0",
-                    "periods": [],
-                },
-                "awayTeam": {
-                    "teamId": int(away_id),
-                    "teamTricode": "",
-                    "teamName": "",
-                    "score": "0",
-                    "periods": [],
-                },
-                "gameStatusText": "Scheduled",
-                "period": 0,
-            }
-
-        if game_linescore is None or game_linescore.empty:
-            return make_scheduled_response(home_team_id, visitor_team_id)
-
-        def build_periods(row):
-            periods = []
-            for q in range(1, 5):
-                col_name = f"PTS_QTR{q}"
-                if col_name in row.index:
-                    score = row[col_name]
-                    if (
-                        score is not None
-                        and str(score) != "nan"
-                        and str(score) != ""
-                        and str(score) != "None"
-                    ):
-                        try:
-                            periods.append(
-                                {"period": q, "score": str(int(float(score)))}
-                            )
-                        except (ValueError, TypeError):
-                            pass
-            for ot in range(1, 11):
-                col_name = f"PTS_OT{ot}"
-                if col_name in row.index:
-                    score = row[col_name]
-                    if (
-                        score is not None
-                        and str(score) != "nan"
-                        and str(score) != ""
-                        and str(score) != "None"
-                    ):
-                        try:
-                            score_int = int(float(score))
-                            if score_int > 0:
-                                periods.append(
-                                    {"period": 4 + ot, "score": str(score_int)}
-                                )
-                        except (ValueError, TypeError):
-                            pass
-            return periods
-
-        def get_game_status(status_id, period):
-            if status_id == 3:
-                if period > 4:
-                    return (
-                        f"Final/OT{period - 4}" if period > 5 else "Final/OT"
-                    )
-                return "Final"
-            elif status_id == 2:
-                if period > 4:
-                    return f"OT{period - 4}"
-                return f"Q{period}"
-            else:
-                return "Scheduled"
-
-        home_filtered = game_linescore[game_linescore["TEAM_ID"] == home_team_id]
-        away_filtered = game_linescore[game_linescore["TEAM_ID"] == visitor_team_id]
-        if home_filtered.empty or away_filtered.empty:
-            return make_scheduled_response(home_team_id, visitor_team_id)
-        home_row = home_filtered.iloc[0]
-        away_row = away_filtered.iloc[0]
-        home_pts = home_row.get("PTS", 0)
-        away_pts = away_row.get("PTS", 0)
-
-        def safe_score(pts):
-            if (
-                pts is None
-                or str(pts) == "nan"
-                or str(pts) == "None"
-                or str(pts) == ""
-            ):
-                return "0"
-            try:
-                return str(int(float(pts)))
-            except (ValueError, TypeError):
-                return "0"
-
-        def get_team_name(row):
-            city = row.get("TEAM_CITY_NAME", "")
-            nickname = (
-                row.get("TEAM_NAME")
-                if "TEAM_NAME" in row.index
-                else row.get("TEAM_NICKNAME", "")
-            )
-            return f"{city} {nickname}".strip()
-
-        return {
-            "homeTeam": {
-                "teamId": int(home_row["TEAM_ID"]),
-                "teamTricode": home_row["TEAM_ABBREVIATION"],
-                "teamName": get_team_name(home_row),
-                "score": safe_score(home_pts),
-                "periods": build_periods(home_row),
-            },
-            "awayTeam": {
-                "teamId": int(away_row["TEAM_ID"]),
-                "teamTricode": away_row["TEAM_ABBREVIATION"],
-                "teamName": get_team_name(away_row),
-                "score": safe_score(away_pts),
-                "periods": build_periods(away_row),
-            },
-            "gameStatusText": get_game_status(
-                game_status_id, int(live_period) if live_period else 0
-            ),
-            "period": int(live_period) if live_period else 0,
-        }
+        return fetch_game_summary(game_id)
     except HTTPException:
         raise
     except Exception as e:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -2,5 +2,6 @@ fastapi
 uvicorn[standard]
 nba_api
 requests
+beautifulsoup4
 numpy
 pandas

--- a/server/services/game_summary.py
+++ b/server/services/game_summary.py
@@ -8,7 +8,6 @@ BREF_TEAM_CODE_OVERRIDES = {
     "HUS": "TRH",
     "BOM": "STB",
     "DEF": "DTF",
-    "WAS": "WSC",
 }
 
 BREF_REQUEST_HEADERS = {
@@ -247,6 +246,137 @@ def build_reliable_bref_periods(home_row, away_row, bref_line_score):
     return None, None
 
 
+def parse_gamecode_team_tricodes(game_code):
+    matchup = str(game_code or "").split("/")[-1]
+    if len(matchup) < 6:
+        return "", ""
+
+    away_tricode = from_bref_team_code(matchup[:3])
+    home_tricode = from_bref_team_code(matchup[3:6])
+    return home_tricode, away_tricode
+
+
+def first_row(filtered):
+    if filtered is None or filtered.empty:
+        return None
+    return filtered.iloc[0]
+
+
+def clean_tricode(value):
+    if value is None or str(value) == "nan" or str(value) == "None":
+        return ""
+    return str(value)
+
+
+def row_tricode(row):
+    if row is None:
+        return ""
+    return clean_tricode(row.get("TEAM_ABBREVIATION"))
+
+
+def bref_period_scores_match_own_total(bref_team_score):
+    if not bref_team_score:
+        return False
+
+    periods = bref_team_score.get("periods")
+    if not periods:
+        return False
+
+    total = bref_team_score.get("total")
+    if total is None:
+        return True
+
+    period_total = 0
+    for period in periods:
+        score = safe_int(period.get("score"))
+        if score is None:
+            return False
+        period_total += score
+
+    return period_total == safe_int(total)
+
+
+def score_from_row_or_bref(row, bref_team_score):
+    if row is not None and safe_int(row.get("PTS")) is not None:
+        return safe_score(row.get("PTS"))
+    if bref_team_score:
+        return safe_score(bref_team_score.get("total"))
+    return "0"
+
+
+def sparse_summary_team(team_id, row, tricode, bref_team_score, periods):
+    return {
+        "teamId": int(team_id),
+        "teamTricode": row_tricode(row) or clean_tricode(tricode),
+        "teamName": get_team_name(row) if row is not None else "",
+        "score": score_from_row_or_bref(row, bref_team_score),
+        "periods": periods,
+    }
+
+
+def make_sparse_linescore_response(
+    game_id,
+    game_meta,
+    home_team_id,
+    visitor_team_id,
+    live_period,
+    game_status_id,
+    home_filtered,
+    away_filtered,
+):
+    home_row = first_row(home_filtered)
+    away_row = first_row(away_filtered)
+    parsed_home_tricode, parsed_away_tricode = parse_gamecode_team_tricodes(
+        game_meta.get("GAMECODE")
+    )
+    home_tricode = row_tricode(home_row) or parsed_home_tricode
+    away_tricode = row_tricode(away_row) or parsed_away_tricode
+    home_periods = []
+    away_periods = []
+    home_bref = None
+    away_bref = None
+    period_score_source = "unavailable"
+
+    if home_tricode and away_tricode:
+        try:
+            bref_line_score = fetch_bref_line_score(
+                game_meta["GAME_DATE_EST"], home_tricode
+            )
+            if bref_line_score:
+                home_bref = bref_line_score.get(home_tricode)
+                away_bref = bref_line_score.get(away_tricode)
+                if (
+                    home_bref
+                    and away_bref
+                    and period_sets_match(
+                        home_bref.get("periods"), away_bref.get("periods")
+                    )
+                    and bref_period_scores_match_own_total(home_bref)
+                    and bref_period_scores_match_own_total(away_bref)
+                ):
+                    home_periods = home_bref.get("periods")
+                    away_periods = away_bref.get("periods")
+                    period_score_source = "basketball-reference"
+        except Exception as e:
+            print(f"Basketball-Reference fallback failed for {game_id}: {e}")
+
+    return {
+        "homeTeam": sparse_summary_team(
+            home_team_id, home_row, home_tricode, home_bref, home_periods
+        ),
+        "awayTeam": sparse_summary_team(
+            visitor_team_id, away_row, away_tricode, away_bref, away_periods
+        ),
+        "gameStatusText": get_game_status(
+            game_status_id,
+            get_status_period(game_status_id, live_period, home_periods, away_periods),
+        ),
+        "period": int(live_period) if live_period else 0,
+        "periodScoreSource": period_score_source,
+        "periodScoreType": "quarters",
+    }
+
+
 def get_game_status(status_id, period):
     if status_id == 3:
         if period > 4:
@@ -334,14 +464,37 @@ def fetch_game_summary(game_id: str):
     game_status_id = game_meta["GAME_STATUS_ID"]
     fallback_linescore = summary.line_score.get_data_frame()
     game_linescore = fallback_linescore if not fallback_linescore.empty else None
+    is_scheduled = safe_int(game_status_id) == 1
 
     if game_linescore is None or game_linescore.empty:
-        return make_scheduled_response(home_team_id, visitor_team_id)
+        if is_scheduled:
+            return make_scheduled_response(home_team_id, visitor_team_id)
+        return make_sparse_linescore_response(
+            game_id,
+            game_meta,
+            home_team_id,
+            visitor_team_id,
+            live_period,
+            game_status_id,
+            None,
+            None,
+        )
 
     home_filtered = game_linescore[game_linescore["TEAM_ID"] == home_team_id]
     away_filtered = game_linescore[game_linescore["TEAM_ID"] == visitor_team_id]
     if home_filtered.empty or away_filtered.empty:
-        return make_scheduled_response(home_team_id, visitor_team_id)
+        if is_scheduled:
+            return make_scheduled_response(home_team_id, visitor_team_id)
+        return make_sparse_linescore_response(
+            game_id,
+            game_meta,
+            home_team_id,
+            visitor_team_id,
+            live_period,
+            game_status_id,
+            home_filtered,
+            away_filtered,
+        )
 
     home_row = home_filtered.iloc[0]
     away_row = away_filtered.iloc[0]

--- a/server/services/game_summary.py
+++ b/server/services/game_summary.py
@@ -1,0 +1,395 @@
+from bs4 import BeautifulSoup, Comment
+from fastapi import HTTPException
+import requests
+from nba_api.stats.endpoints import boxscoresummaryv2, boxscoretraditionalv3
+
+
+BREF_TEAM_CODE_OVERRIDES = {
+    "HUS": "TRH",
+    "BOM": "STB",
+    "DEF": "DTF",
+    "WAS": "WSC",
+}
+
+BREF_REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+    )
+}
+
+BREF_REQUEST_TIMEOUT_SECONDS = 2
+BREF_LINE_SCORE_CACHE: dict[tuple[str, str], dict | None] = {}
+
+
+def safe_score(pts):
+    if (
+        pts is None
+        or str(pts) == "nan"
+        or str(pts) == "None"
+        or str(pts) == ""
+    ):
+        return "0"
+    try:
+        return str(int(float(pts)))
+    except (ValueError, TypeError):
+        return "0"
+
+
+def safe_int(value):
+    if (
+        value is None
+        or str(value) == "nan"
+        or str(value) == "None"
+        or str(value) == ""
+    ):
+        return None
+    try:
+        return int(float(value))
+    except (ValueError, TypeError):
+        return None
+
+
+def to_bref_team_code(team_tricode):
+    return BREF_TEAM_CODE_OVERRIDES.get(str(team_tricode), str(team_tricode))
+
+
+def from_bref_team_code(team_code):
+    reverse_overrides = {v: k for k, v in BREF_TEAM_CODE_OVERRIDES.items()}
+    return reverse_overrides.get(str(team_code), str(team_code))
+
+
+def build_bref_boxscore_url(game_date_est, home_team_tricode):
+    date_key = str(game_date_est)[:10].replace("-", "")
+    return (
+        "https://www.basketball-reference.com/boxscores/"
+        f"{date_key}0{to_bref_team_code(home_team_tricode)}.html"
+    )
+
+
+def extract_bref_line_score(html):
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table", id="line_score")
+
+    if table is None:
+        for comment in soup.find_all(string=lambda text: isinstance(text, Comment)):
+            if 'id="line_score"' not in comment:
+                continue
+            comment_soup = BeautifulSoup(comment, "html.parser")
+            table = comment_soup.find("table", id="line_score")
+            if table is not None:
+                break
+
+    if table is None:
+        return None
+
+    scores = {}
+    for row in table.select("tbody tr"):
+        team_cell = row.find(["th", "td"], attrs={"data-stat": "team"})
+        if team_cell is None:
+            continue
+
+        team_code = from_bref_team_code(team_cell.get_text(strip=True))
+        periods = []
+        total = None
+
+        for cell in row.find_all("td"):
+            data_stat = cell.get("data-stat")
+            score = safe_int(cell.get_text(strip=True))
+            if data_stat == "T":
+                total = score
+                break
+            if score is None:
+                continue
+            periods.append({"period": len(periods) + 1, "score": str(score)})
+
+        if team_code and periods:
+            scores[team_code] = {"periods": periods, "total": total}
+
+    return scores or None
+
+
+def fetch_bref_line_score(game_date_est, home_team_tricode):
+    cache_key = (str(game_date_est)[:10], str(home_team_tricode))
+    if cache_key in BREF_LINE_SCORE_CACHE:
+        return BREF_LINE_SCORE_CACHE[cache_key]
+
+    url = build_bref_boxscore_url(game_date_est, home_team_tricode)
+    response = requests.get(
+        url, headers=BREF_REQUEST_HEADERS, timeout=BREF_REQUEST_TIMEOUT_SECONDS
+    )
+    response.raise_for_status()
+    line_score = extract_bref_line_score(response.text)
+    BREF_LINE_SCORE_CACHE[cache_key] = line_score
+    return line_score
+
+
+def build_reliable_nba_periods(home_row, away_row, is_final=True):
+    if is_final:
+        home_periods = build_complete_periods(home_row)
+        away_periods = build_complete_periods(away_row)
+    else:
+        home_periods = build_available_periods(home_row)
+        away_periods = build_available_periods(away_row)
+
+    if not period_sets_match(home_periods, away_periods):
+        return None, None
+
+    if period_scores_match_total(home_row, home_periods) and period_scores_match_total(
+        away_row, away_periods
+    ):
+        return home_periods, away_periods
+
+    return None, None
+
+
+def build_complete_periods(row):
+    periods = []
+    for q in range(1, 5):
+        score = safe_int(row.get(f"PTS_QTR{q}"))
+        if score is None:
+            return []
+        periods.append({"period": q, "score": str(score)})
+
+    for ot in range(1, 11):
+        score = safe_int(row.get(f"PTS_OT{ot}"))
+        if score is None or score == 0:
+            continue
+        if score < 0:
+            return []
+        periods.append({"period": 4 + ot, "score": str(score)})
+
+    return periods
+
+
+def build_available_periods(row):
+    periods = []
+    for q in range(1, 5):
+        score = safe_int(row.get(f"PTS_QTR{q}"))
+        if score is None:
+            continue
+        periods.append({"period": q, "score": str(score)})
+
+    for ot in range(1, 11):
+        score = safe_int(row.get(f"PTS_OT{ot}"))
+        if score is None or score == 0:
+            continue
+        if score < 0:
+            return []
+        periods.append({"period": 4 + ot, "score": str(score)})
+
+    return periods
+
+
+def period_sets_match(home_periods, away_periods):
+    if not home_periods or len(home_periods) != len(away_periods):
+        return False
+    return all(
+        period["period"] == away_periods[index]["period"]
+        for index, period in enumerate(home_periods)
+    )
+
+
+def period_scores_match_total(row, periods):
+    total = safe_int(row.get("PTS"))
+    if total is None or not periods:
+        return False
+
+    period_total = sum(safe_int(period["score"]) or 0 for period in periods)
+    return period_total == total
+
+
+def bref_period_scores_match_total(expected_total, bref_team_score):
+    total = safe_int(expected_total)
+    if total is None or not bref_team_score:
+        return False
+
+    periods = bref_team_score.get("periods")
+    if not periods:
+        return False
+
+    period_total = 0
+    for period in periods:
+        score = safe_int(period.get("score"))
+        if score is None:
+            return False
+        period_total += score
+
+    if period_total != total:
+        return False
+
+    bref_total = bref_team_score.get("total")
+    if bref_total is not None and safe_int(bref_total) != total:
+        return False
+
+    return True
+
+
+def build_reliable_bref_periods(home_row, away_row, bref_line_score):
+    if not bref_line_score:
+        return None, None
+
+    home_bref = bref_line_score.get(home_row["TEAM_ABBREVIATION"])
+    away_bref = bref_line_score.get(away_row["TEAM_ABBREVIATION"])
+    if not home_bref or not away_bref:
+        return None, None
+
+    home_periods = home_bref.get("periods")
+    away_periods = away_bref.get("periods")
+    if not period_sets_match(home_periods, away_periods):
+        return None, None
+
+    if bref_period_scores_match_total(
+        home_row.get("PTS"), home_bref
+    ) and bref_period_scores_match_total(away_row.get("PTS"), away_bref):
+        return home_periods, away_periods
+
+    return None, None
+
+
+def get_game_status(status_id, period):
+    if status_id == 3:
+        if period > 4:
+            return f"Final/OT{period - 4}" if period > 5 else "Final/OT"
+        return "Final"
+    elif status_id == 2:
+        if period > 4:
+            return f"OT{period - 4}"
+        return f"Q{period}"
+    else:
+        return "Scheduled"
+
+
+def get_status_period(status_id, live_period, home_periods, away_periods):
+    period = safe_int(live_period) or 0
+
+    if status_id != 3:
+        return period
+
+    if period_sets_match(home_periods, away_periods):
+        return max(safe_int(period_score.get("period")) or 0 for period_score in home_periods)
+
+    return period
+
+
+def get_team_name(row):
+    city = row.get("TEAM_CITY_NAME", "")
+    nickname = (
+        row.get("TEAM_NAME")
+        if "TEAM_NAME" in row.index
+        else row.get("TEAM_NICKNAME", "")
+    )
+    return f"{city} {nickname}".strip()
+
+
+def make_scheduled_response(home_id, away_id):
+    return {
+        "homeTeam": {
+            "teamId": int(home_id),
+            "teamTricode": "",
+            "teamName": "",
+            "score": "0",
+            "periods": [],
+        },
+        "awayTeam": {
+            "teamId": int(away_id),
+            "teamTricode": "",
+            "teamName": "",
+            "score": "0",
+            "periods": [],
+        },
+        "gameStatusText": "Scheduled",
+        "period": 0,
+        "periodScoreSource": "unavailable",
+        "periodScoreType": "quarters",
+    }
+
+
+def fetch_boxscoretraditional(game_id: str):
+    box = boxscoretraditionalv3.BoxScoreTraditionalV3(
+        game_id=game_id,
+        range_type=0,
+        start_period=0,
+        end_period=10,
+        start_range=0,
+        end_range=0,
+    )
+    data = box.get_dict()
+    game = data.get("boxScoreTraditional")
+    if not game or not game.get("homeTeam") or not game.get("awayTeam"):
+        raise ValueError("BoxscoreTraditionalV3 returned no usable game data")
+    return game
+
+
+def fetch_game_summary(game_id: str):
+    summary = boxscoresummaryv2.BoxScoreSummaryV2(game_id=game_id)
+    game_summary_df = summary.game_summary.get_data_frame()
+    if game_summary_df.empty:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    game_meta = game_summary_df.iloc[0]
+    home_team_id = game_meta["HOME_TEAM_ID"]
+    visitor_team_id = game_meta["VISITOR_TEAM_ID"]
+    live_period = game_meta["LIVE_PERIOD"]
+    game_status_id = game_meta["GAME_STATUS_ID"]
+    fallback_linescore = summary.line_score.get_data_frame()
+    game_linescore = fallback_linescore if not fallback_linescore.empty else None
+
+    if game_linescore is None or game_linescore.empty:
+        return make_scheduled_response(home_team_id, visitor_team_id)
+
+    home_filtered = game_linescore[game_linescore["TEAM_ID"] == home_team_id]
+    away_filtered = game_linescore[game_linescore["TEAM_ID"] == visitor_team_id]
+    if home_filtered.empty or away_filtered.empty:
+        return make_scheduled_response(home_team_id, visitor_team_id)
+
+    home_row = home_filtered.iloc[0]
+    away_row = away_filtered.iloc[0]
+    home_pts = home_row.get("PTS", 0)
+    away_pts = away_row.get("PTS", 0)
+    home_periods, away_periods = build_reliable_nba_periods(
+        home_row, away_row, game_status_id == 3
+    )
+    period_score_source = "nba"
+
+    if home_periods is None or away_periods is None:
+        period_score_source = "unavailable"
+        home_periods = []
+        away_periods = []
+        try:
+            bref_line_score = fetch_bref_line_score(
+                game_meta["GAME_DATE_EST"], home_row["TEAM_ABBREVIATION"]
+            )
+            home_bref_periods, away_bref_periods = build_reliable_bref_periods(
+                home_row, away_row, bref_line_score
+            )
+            if home_bref_periods is not None and away_bref_periods is not None:
+                home_periods = home_bref_periods
+                away_periods = away_bref_periods
+                period_score_source = "basketball-reference"
+        except Exception as e:
+            print(f"Basketball-Reference fallback failed for {game_id}: {e}")
+
+    return {
+        "homeTeam": {
+            "teamId": int(home_row["TEAM_ID"]),
+            "teamTricode": home_row["TEAM_ABBREVIATION"],
+            "teamName": get_team_name(home_row),
+            "score": safe_score(home_pts),
+            "periods": home_periods,
+        },
+        "awayTeam": {
+            "teamId": int(away_row["TEAM_ID"]),
+            "teamTricode": away_row["TEAM_ABBREVIATION"],
+            "teamName": get_team_name(away_row),
+            "score": safe_score(away_pts),
+            "periods": away_periods,
+        },
+        "gameStatusText": get_game_status(
+            game_status_id,
+            get_status_period(game_status_id, live_period, home_periods, away_periods),
+        ),
+        "period": int(live_period) if live_period else 0,
+        "periodScoreSource": period_score_source,
+        "periodScoreType": "quarters",
+    }

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -713,6 +713,17 @@ def determine_winner(home_team, away_team, home_score, away_score):
     return home_team if home_score > away_score else away_team
 
 
+def get_playoff_game_status(row) -> int | None:
+    for key in ("GAME_STATUS_ID", "GAME_STATUS", "gameStatus"):
+        if key in row and row.get(key) is not None:
+            return int(row[key])
+
+    if row.get("WL") in {"W", "L"} and row.get("PTS") is not None:
+        return 3
+
+    return 1
+
+
 def normalize_playoff_games(df):
     normalized_games = []
 
@@ -743,6 +754,7 @@ def normalize_playoff_games(df):
                 "boxscoreAvailable": is_boxscore_available_metadata(
                     str(game_id),
                     home_team["GAME_DATE"],
+                    get_playoff_game_status(home_team),
                 ),
                 "round": 0,
                 "roundName": "Round 0",

--- a/server/services/playoffs.py
+++ b/server/services/playoffs.py
@@ -9,6 +9,7 @@ from nba_api.stats.endpoints import LeagueGameLog, boxscoresummaryv2, leaguegame
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import ReadTimeout
 
+from server.utils.boxscore_availability import is_boxscore_available_metadata
 from server.utils.season import get_nba_season
 
 _CONFERENCES_JSON = (
@@ -739,6 +740,10 @@ def normalize_playoff_games(df):
             {
                 "gameId": str(game_id),
                 "date": home_team["GAME_DATE"],
+                "boxscoreAvailable": is_boxscore_available_metadata(
+                    str(game_id),
+                    home_team["GAME_DATE"],
+                ),
                 "round": 0,
                 "roundName": "Round 0",
                 "homeTeam": {

--- a/server/tests/test_boxscore_availability.py
+++ b/server/tests/test_boxscore_availability.py
@@ -26,6 +26,10 @@ def test_boxscore_metadata_unavailable_for_scheduled_game():
     assert is_boxscore_available_metadata("0024600206", "2024-11-01", 1) is False
 
 
+def test_boxscore_metadata_unavailable_for_missing_status():
+    assert is_boxscore_available_metadata("0024600206", "2024-11-01", None) is False
+
+
 def test_boxscore_metadata_unavailable_for_invalid_game_id():
     assert is_boxscore_available_metadata("not-a-game", "2024-11-01", 2) is False
 
@@ -78,6 +82,7 @@ def test_playoff_normalization_adds_boxscore_availability():
             "TEAM_NAME": "Celtics",
             "WL": "W",
             "PTS": 107,
+            "GAME_STATUS_ID": 3,
         },
         {
             "GAME_ID": "0042300401",
@@ -88,12 +93,45 @@ def test_playoff_normalization_adds_boxscore_availability():
             "TEAM_NAME": "Mavericks",
             "WL": "L",
             "PTS": 89,
+            "GAME_STATUS_ID": 3,
         },
     ]
 
     result = playoffs.normalize_playoff_games(pandas.DataFrame(rows))
 
     assert result[0]["boxscoreAvailable"] is True
+
+
+def test_playoff_normalization_marks_scheduled_game_unavailable():
+    pandas = pytest.importorskip("pandas")
+    rows = [
+        {
+            "GAME_ID": "0042500401",
+            "GAME_DATE": "2026-06-04",
+            "MATCHUP": "BOS vs. DAL",
+            "TEAM_ID": 1610612738,
+            "TEAM_ABBREVIATION": "BOS",
+            "TEAM_NAME": "Celtics",
+            "WL": None,
+            "PTS": 0,
+            "GAME_STATUS_ID": 1,
+        },
+        {
+            "GAME_ID": "0042500401",
+            "GAME_DATE": "2026-06-04",
+            "MATCHUP": "DAL @ BOS",
+            "TEAM_ID": 1610612742,
+            "TEAM_ABBREVIATION": "DAL",
+            "TEAM_NAME": "Mavericks",
+            "WL": None,
+            "PTS": 0,
+            "GAME_STATUS_ID": 1,
+        },
+    ]
+
+    result = playoffs.normalize_playoff_games(pandas.DataFrame(rows))
+
+    assert result[0]["boxscoreAvailable"] is False
 
 
 def test_existing_boxscore_endpoint_still_errors_on_upstream_failure(monkeypatch):
@@ -109,3 +147,19 @@ def test_existing_boxscore_endpoint_still_errors_on_upstream_failure(monkeypatch
 
     assert exc.value.status_code == 500
     assert "Failed to fetch boxscore" in exc.value.detail
+
+
+def test_boxscore_endpoint_maps_unavailable_data_to_not_found(monkeypatch):
+    def fake_boxscore(*args, **kwargs):
+        return _FakeBoxScoreTraditional(payload={"boxScoreTraditional": None})
+
+    monkeypatch.setattr(
+        game_summary.boxscoretraditionalv3, "BoxScoreTraditionalV3", fake_boxscore
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        main.get_game_boxscore("0024600206")
+
+    assert exc.value.status_code == 404
+    assert "Boxscore unavailable" in exc.value.detail
+    assert "no usable game data" in exc.value.detail

--- a/server/tests/test_boxscore_availability.py
+++ b/server/tests/test_boxscore_availability.py
@@ -1,0 +1,111 @@
+import pytest
+from fastapi import HTTPException
+
+from server import main
+from server.services import game_summary
+from server.services import playoffs
+from server.utils.boxscore_availability import is_boxscore_available_metadata
+
+
+class _FakeBoxScoreTraditional:
+    def __init__(self, payload=None, error=None):
+        self.payload = payload
+        self.error = error
+
+    def get_dict(self):
+        if self.error:
+            raise self.error
+        return self.payload
+
+
+def test_boxscore_metadata_available_for_started_supported_game():
+    assert is_boxscore_available_metadata("0024600206", "2024-11-01", 2) is True
+
+
+def test_boxscore_metadata_unavailable_for_scheduled_game():
+    assert is_boxscore_available_metadata("0024600206", "2024-11-01", 1) is False
+
+
+def test_boxscore_metadata_unavailable_for_invalid_game_id():
+    assert is_boxscore_available_metadata("not-a-game", "2024-11-01", 2) is False
+
+
+def test_boxscore_metadata_available_for_historical_started_game():
+    assert is_boxscore_available_metadata("0024600206", "1996-10-31", 2) is True
+
+
+class _FakeScoreboardV3:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def get_dict(self):
+        return {
+            "scoreboard": {
+                "games": [
+                    {
+                        "gameId": "0024600206",
+                        "gameTimeUTC": "2024-11-01T23:00:00Z",
+                        "gameStatus": 2,
+                    },
+                    {
+                        "gameId": "0024600207",
+                        "gameTimeUTC": "2024-11-01T23:30:00Z",
+                        "gameStatus": 1,
+                    },
+                ],
+            },
+        }
+
+
+def test_scoreboard_route_adds_boxscore_availability(monkeypatch):
+    monkeypatch.setattr(main.scoreboardv3, "ScoreboardV3", _FakeScoreboardV3)
+
+    result = main.get_v3_scoreboard(date="2024-11-01")
+
+    assert result["games"][0]["boxscoreAvailable"] is True
+    assert result["games"][1]["boxscoreAvailable"] is False
+
+
+def test_playoff_normalization_adds_boxscore_availability():
+    pandas = pytest.importorskip("pandas")
+    rows = [
+        {
+            "GAME_ID": "0042300401",
+            "GAME_DATE": "2024-06-06",
+            "MATCHUP": "BOS vs. DAL",
+            "TEAM_ID": 1610612738,
+            "TEAM_ABBREVIATION": "BOS",
+            "TEAM_NAME": "Celtics",
+            "WL": "W",
+            "PTS": 107,
+        },
+        {
+            "GAME_ID": "0042300401",
+            "GAME_DATE": "2024-06-06",
+            "MATCHUP": "DAL @ BOS",
+            "TEAM_ID": 1610612742,
+            "TEAM_ABBREVIATION": "DAL",
+            "TEAM_NAME": "Mavericks",
+            "WL": "L",
+            "PTS": 89,
+        },
+    ]
+
+    result = playoffs.normalize_playoff_games(pandas.DataFrame(rows))
+
+    assert result[0]["boxscoreAvailable"] is True
+
+
+def test_existing_boxscore_endpoint_still_errors_on_upstream_failure(monkeypatch):
+    def fake_boxscore(*args, **kwargs):
+        return _FakeBoxScoreTraditional(error=RuntimeError("NBA endpoint failed"))
+
+    monkeypatch.setattr(
+        game_summary.boxscoretraditionalv3, "BoxScoreTraditionalV3", fake_boxscore
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        main.get_game_boxscore("0024600206")
+
+    assert exc.value.status_code == 500
+    assert "Failed to fetch boxscore" in exc.value.detail

--- a/server/tests/test_game_summary_periods.py
+++ b/server/tests/test_game_summary_periods.py
@@ -48,14 +48,17 @@ class _FakeResponse:
         pass
 
 
-def _game_summary_row():
-    return {
+def _game_summary_row(**overrides):
+    row = {
         "GAME_DATE_EST": "1946-11-01T00:00:00",
+        "GAMECODE": "19461101/NYKTRH",
         "HOME_TEAM_ID": HUS,
         "VISITOR_TEAM_ID": NYK,
         "LIVE_PERIOD": 5,
         "GAME_STATUS_ID": 3,
     }
+    row.update(overrides)
+    return row
 
 
 def _line_score_row(team_id, tricode, city, nickname, pts, qtrs=None, ot1=None):
@@ -371,7 +374,126 @@ def test_fallback_failure_returns_no_periods(monkeypatch):
     assert result["awayTeam"]["periods"] == []
 
 
+def test_scheduled_empty_linescore_does_not_call_bref(monkeypatch):
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row(GAME_STATUS_ID=1, LIVE_PERIOD=0)],
+        [],
+    )
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected")),
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    assert result["gameStatusText"] == "Scheduled"
+    assert result["periodScoreSource"] == "unavailable"
+
+
+def test_final_empty_linescore_uses_bref_fallback(monkeypatch):
+    calls = []
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row(LIVE_PERIOD=4)],
+        [],
+    )
+
+    def fake_bref(game_date_est, home_team_tricode):
+        calls.append((game_date_est, home_team_tricode))
+        return {
+            "HUS": _bref_score([12, 17, 19, 18], 66),
+            "NYK": _bref_score([16, 21, 6, 25], 68),
+        }
+
+    monkeypatch.setattr(game_summary, "fetch_bref_line_score", fake_bref)
+
+    result = main.get_game_summary("0024600001")
+
+    assert calls == [("1946-11-01T00:00:00", "HUS")]
+    assert result["periodScoreSource"] == "basketball-reference"
+    assert result["gameStatusText"] == "Final"
+    assert result["homeTeam"]["score"] == "66"
+    assert result["awayTeam"]["score"] == "68"
+    assert [period["score"] for period in result["homeTeam"]["periods"]] == [
+        "12",
+        "17",
+        "19",
+        "18",
+    ]
+    assert [period["score"] for period in result["awayTeam"]["periods"]] == [
+        "16",
+        "21",
+        "6",
+        "25",
+    ]
+
+
+def test_final_sparse_linescore_uses_bref_fallback(monkeypatch):
+    calls = []
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row(LIVE_PERIOD=4)],
+        [_line_score_row(HUS, "HUS", "Toronto", "Huskies", 66)],
+    )
+
+    def fake_bref(game_date_est, home_team_tricode):
+        calls.append((game_date_est, home_team_tricode))
+        return {
+            "HUS": _bref_score([12, 17, 19, 18], 66),
+            "NYK": _bref_score([16, 21, 6, 25], 68),
+        }
+
+    monkeypatch.setattr(game_summary, "fetch_bref_line_score", fake_bref)
+
+    result = main.get_game_summary("0024600001")
+
+    assert calls == [("1946-11-01T00:00:00", "HUS")]
+    assert result["periodScoreSource"] == "basketball-reference"
+    assert result["homeTeam"]["teamName"] == "Toronto Huskies"
+    assert result["homeTeam"]["score"] == "66"
+    assert result["awayTeam"]["teamTricode"] == "NYK"
+    assert result["awayTeam"]["score"] == "68"
+    assert [period["score"] for period in result["awayTeam"]["periods"]] == [
+        "16",
+        "21",
+        "6",
+        "25",
+    ]
+
+
+def test_final_empty_linescore_bref_failure_is_not_scheduled(monkeypatch):
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row(LIVE_PERIOD=4)],
+        [],
+    )
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    assert result["gameStatusText"] == "Final"
+    assert result["periodScoreSource"] == "unavailable"
+    assert result["homeTeam"]["periods"] == []
+    assert result["awayTeam"]["periods"] == []
+
+
 def test_bref_url_uses_historical_home_team_mapping():
     assert game_summary.build_bref_boxscore_url(
         "1946-11-01T00:00:00", "HUS"
     ) == "https://www.basketball-reference.com/boxscores/194611010TRH.html"
+
+
+def test_bref_url_preserves_modern_wizards_home_team_code():
+    assert game_summary.build_bref_boxscore_url(
+        "2024-01-31T00:00:00", "WAS"
+    ) == "https://www.basketball-reference.com/boxscores/202401310WAS.html"
+
+
+def test_bref_parser_preserves_modern_wizards_team_code():
+    assert game_summary.from_bref_team_code("WAS") == "WAS"

--- a/server/tests/test_game_summary_periods.py
+++ b/server/tests/test_game_summary_periods.py
@@ -1,0 +1,377 @@
+import pandas as pd
+import pytest
+
+from server import main
+from server.services import game_summary
+
+
+HUS = 1610610035
+NYK = 1610612752
+
+BREF_LINE_SCORE_HTML = """
+<!--
+<table id="line_score">
+  <tbody>
+    <tr><th data-stat="team">NYK</th>
+      <td data-stat="1">16</td><td data-stat="2">21</td>
+      <td data-stat="3">6</td><td data-stat="4">25</td>
+      <td data-stat="T"><strong>68</strong></td></tr>
+    <tr><th data-stat="team">TRH</th>
+      <td data-stat="1">12</td><td data-stat="2">17</td>
+      <td data-stat="3">19</td><td data-stat="4">18</td>
+      <td data-stat="T"><strong>66</strong></td></tr>
+  </tbody>
+</table>
+-->
+"""
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def get_data_frame(self):
+        return pd.DataFrame(self.rows)
+
+
+class _FakeSummary:
+    def __init__(self, game_summary_rows, line_score_rows):
+        self.game_summary = _FakeResult(game_summary_rows)
+        self.line_score = _FakeResult(line_score_rows)
+
+
+class _FakeResponse:
+    def __init__(self, text):
+        self.text = text
+
+    def raise_for_status(self):
+        pass
+
+
+def _game_summary_row():
+    return {
+        "GAME_DATE_EST": "1946-11-01T00:00:00",
+        "HOME_TEAM_ID": HUS,
+        "VISITOR_TEAM_ID": NYK,
+        "LIVE_PERIOD": 5,
+        "GAME_STATUS_ID": 3,
+    }
+
+
+def _line_score_row(team_id, tricode, city, nickname, pts, qtrs=None, ot1=None):
+    row = {
+        "TEAM_ID": team_id,
+        "TEAM_ABBREVIATION": tricode,
+        "TEAM_CITY_NAME": city,
+        "TEAM_NICKNAME": nickname,
+        "PTS": pts,
+    }
+    qtrs = qtrs if qtrs is not None else [None, None, None, None]
+    for index, score in enumerate(qtrs, start=1):
+        row[f"PTS_QTR{index}"] = score
+    for index in range(1, 11):
+        row[f"PTS_OT{index}"] = ot1 if index == 1 else None
+    return row
+
+
+def _patch_summary(monkeypatch, game_summary_rows, line_score_rows):
+    class FakeBoxScoreSummaryV2:
+        def __init__(self, *args, **kwargs):
+            self._summary = _FakeSummary(game_summary_rows, line_score_rows)
+            self.game_summary = self._summary.game_summary
+            self.line_score = self._summary.line_score
+
+    monkeypatch.setattr(
+        game_summary.boxscoresummaryv2, "BoxScoreSummaryV2", FakeBoxScoreSummaryV2
+    )
+
+
+def _bref_score(period_scores, total):
+    return {
+        "periods": [
+            {"period": period, "score": str(score)}
+            for period, score in enumerate(period_scores, start=1)
+        ],
+        "total": total,
+    }
+
+
+def _patch_invalid_nba_period_summary(monkeypatch):
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row()],
+        [
+            _line_score_row(HUS, "HUS", "Toronto", "Huskies", 66, ot1=18),
+            _line_score_row(NYK, "NYK", "New York", "Knicks", 68, ot1=24),
+        ],
+    )
+
+
+def _assert_no_period_fallback(result):
+    assert result["periodScoreSource"] == "unavailable"
+    assert result["homeTeam"]["periods"] == []
+    assert result["awayTeam"]["periods"] == []
+
+
+def test_bref_fetch_uses_short_timeout(monkeypatch):
+    calls = []
+    monkeypatch.setattr(game_summary, "BREF_LINE_SCORE_CACHE", {})
+
+    def fake_get(url, headers, timeout):
+        calls.append({"url": url, "headers": headers, "timeout": timeout})
+        return _FakeResponse(BREF_LINE_SCORE_HTML)
+
+    monkeypatch.setattr(game_summary.requests, "get", fake_get)
+
+    game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+
+    assert game_summary.BREF_REQUEST_TIMEOUT_SECONDS == 2
+    assert calls[0]["timeout"] == game_summary.BREF_REQUEST_TIMEOUT_SECONDS
+
+
+def test_bref_fetch_caches_successful_parse(monkeypatch):
+    calls = []
+    monkeypatch.setattr(game_summary, "BREF_LINE_SCORE_CACHE", {})
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _FakeResponse(BREF_LINE_SCORE_HTML)
+
+    monkeypatch.setattr(game_summary.requests, "get", fake_get)
+
+    first = game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+    second = game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+
+    assert len(calls) == 1
+    assert first == second
+    assert [period["score"] for period in second["HUS"]["periods"]] == [
+        "12",
+        "17",
+        "19",
+        "18",
+    ]
+
+
+def test_bref_fetch_caches_missing_line_score(monkeypatch):
+    calls = []
+    monkeypatch.setattr(game_summary, "BREF_LINE_SCORE_CACHE", {})
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _FakeResponse("<html></html>")
+
+    monkeypatch.setattr(game_summary.requests, "get", fake_get)
+
+    first = game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+    second = game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+
+    assert first is None
+    assert second is None
+    assert len(calls) == 1
+
+
+def test_bref_fetch_does_not_cache_transport_failure(monkeypatch):
+    calls = []
+    monkeypatch.setattr(game_summary, "BREF_LINE_SCORE_CACHE", {})
+
+    def fake_get(*args, **kwargs):
+        calls.append((args, kwargs))
+        if len(calls) == 1:
+            raise game_summary.requests.exceptions.Timeout("timed out")
+        return _FakeResponse(BREF_LINE_SCORE_HTML)
+
+    monkeypatch.setattr(game_summary.requests, "get", fake_get)
+
+    with pytest.raises(game_summary.requests.exceptions.Timeout):
+        game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+
+    result = game_summary.fetch_bref_line_score("1946-11-01T00:00:00", "HUS")
+
+    assert len(calls) == 2
+    assert result["HUS"]["total"] == 66
+
+
+def test_invalid_nba_period_data_uses_bref_fallback(monkeypatch):
+    calls = []
+    _patch_invalid_nba_period_summary(monkeypatch)
+
+    def fake_bref(game_date_est, home_team_tricode):
+        calls.append((game_date_est, home_team_tricode))
+        return {
+            "HUS": _bref_score([12, 17, 19, 18], 66),
+            "NYK": _bref_score([16, 21, 6, 25], 68),
+        }
+
+    monkeypatch.setattr(game_summary, "fetch_bref_line_score", fake_bref)
+
+    result = main.get_game_summary("0024600001")
+
+    assert calls == [("1946-11-01T00:00:00", "HUS")]
+    assert result["periodScoreSource"] == "basketball-reference"
+    assert result["gameStatusText"] == "Final"
+    assert [period["score"] for period in result["homeTeam"]["periods"]] == [
+        "12",
+        "17",
+        "19",
+        "18",
+    ]
+    assert [period["score"] for period in result["awayTeam"]["periods"]] == [
+        "16",
+        "21",
+        "6",
+        "25",
+    ]
+
+
+def test_bref_fallback_rejects_period_sum_mismatch(monkeypatch):
+    _patch_invalid_nba_period_summary(monkeypatch)
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: {
+            "HUS": _bref_score([12, 17, 19, 17], 65),
+            "NYK": _bref_score([16, 21, 6, 25], 68),
+        },
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    _assert_no_period_fallback(result)
+
+
+def test_bref_fallback_rejects_parsed_total_mismatch(monkeypatch):
+    _patch_invalid_nba_period_summary(monkeypatch)
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: {
+            "HUS": _bref_score([12, 17, 19, 18], 67),
+            "NYK": _bref_score([16, 21, 6, 25], 68),
+        },
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    _assert_no_period_fallback(result)
+
+
+def test_bref_fallback_rejects_mismatched_period_sets(monkeypatch):
+    _patch_invalid_nba_period_summary(monkeypatch)
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: {
+            "HUS": _bref_score([12, 17, 19, 18], 66),
+            "NYK": _bref_score([16, 21, 6, 20, 5], 68),
+        },
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    _assert_no_period_fallback(result)
+
+
+def test_bref_parser_extracts_commented_line_score():
+    result = game_summary.extract_bref_line_score(BREF_LINE_SCORE_HTML)
+
+    assert [period["score"] for period in result["NYK"]["periods"]] == [
+        "16",
+        "21",
+        "6",
+        "25",
+    ]
+    assert [period["score"] for period in result["HUS"]["periods"]] == [
+        "12",
+        "17",
+        "19",
+        "18",
+    ]
+    assert result["NYK"]["total"] == 68
+    assert result["HUS"]["total"] == 66
+
+
+def test_valid_nba_period_data_does_not_call_bref(monkeypatch):
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row()],
+        [
+            _line_score_row(HUS, "HUS", "Toronto", "Huskies", 66, [12, 17, 19, 18]),
+            _line_score_row(NYK, "NYK", "New York", "Knicks", 68, [16, 21, 6, 25]),
+        ],
+    )
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected")),
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    assert result["periodScoreSource"] == "nba"
+    assert result["gameStatusText"] == "Final"
+    assert [period["score"] for period in result["homeTeam"]["periods"]] == [
+        "12",
+        "17",
+        "19",
+        "18",
+    ]
+
+
+def test_final_overtime_status_uses_validated_periods(monkeypatch):
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row()],
+        [
+            _line_score_row(
+                HUS, "HUS", "Toronto", "Huskies", 84, [12, 17, 19, 18], ot1=18
+            ),
+            _line_score_row(
+                NYK, "NYK", "New York", "Knicks", 92, [16, 21, 6, 25], ot1=24
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("unexpected")),
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    assert result["periodScoreSource"] == "nba"
+    assert result["gameStatusText"] == "Final/OT"
+    assert [period["period"] for period in result["homeTeam"]["periods"]] == [
+        1,
+        2,
+        3,
+        4,
+        5,
+    ]
+
+
+def test_fallback_failure_returns_no_periods(monkeypatch):
+    _patch_summary(
+        monkeypatch,
+        [_game_summary_row()],
+        [
+            _line_score_row(HUS, "HUS", "Toronto", "Huskies", 66, ot1=18),
+            _line_score_row(NYK, "NYK", "New York", "Knicks", 68, ot1=24),
+        ],
+    )
+    monkeypatch.setattr(
+        game_summary,
+        "fetch_bref_line_score",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("offline")),
+    )
+
+    result = main.get_game_summary("0024600001")
+
+    assert result["periodScoreSource"] == "unavailable"
+    assert result["homeTeam"]["periods"] == []
+    assert result["awayTeam"]["periods"] == []
+
+
+def test_bref_url_uses_historical_home_team_mapping():
+    assert game_summary.build_bref_boxscore_url(
+        "1946-11-01T00:00:00", "HUS"
+    ) == "https://www.basketball-reference.com/boxscores/194611010TRH.html"

--- a/server/utils/boxscore_availability.py
+++ b/server/utils/boxscore_availability.py
@@ -1,0 +1,14 @@
+def is_valid_nba_game_id(game_id: str | None) -> bool:
+    return isinstance(game_id, str) and game_id.isdigit() and len(game_id) == 10
+
+
+def is_boxscore_available_metadata(
+    game_id: str | None,
+    game_date: str | None,
+    game_status: int | None = None,
+) -> bool:
+    if not is_valid_nba_game_id(game_id):
+        return False
+    if game_status == 1:
+        return False
+    return True

--- a/server/utils/boxscore_availability.py
+++ b/server/utils/boxscore_availability.py
@@ -5,9 +5,11 @@ def is_valid_nba_game_id(game_id: str | None) -> bool:
 def is_boxscore_available_metadata(
     game_id: str | None,
     game_date: str | None,
-    game_status: int | None = None,
+    game_status: int | None,
 ) -> bool:
     if not is_valid_nba_game_id(game_id):
+        return False
+    if game_status is None:
         return False
     if game_status == 1:
         return False

--- a/src/components/GameSummary.tsx
+++ b/src/components/GameSummary.tsx
@@ -1,33 +1,10 @@
 // import OvertimeHead from "@/components/Overtime";
+import type { GameSummaryData, PeriodScore } from "@/helpers/helpers";
 import TeamLogos from "./TeamLogos";
 import {ArrowIconRight, ArrowIconLeft} from "./ArrowIcon";
 
-interface PeriodScore {
-  period: number;
-  score: string;
-}
-
 interface GameProps {
-  game: {
-    homeTeam: {
-      teamId: number;
-      teamTricode: string;
-      teamName: string;
-      periods: PeriodScore[];
-      score: string;
-    };
-    awayTeam: {
-      teamId: number;
-      teamTricode: string;
-      teamName: string;
-      periods: PeriodScore[];
-      score: string;
-    };
-    period: number;
-    gameStatusText: string;
-    periodScoreSource?: "nba" | "basketball-reference" | "unavailable";
-    periodScoreType?: "quarters";
-  };
+  game: GameSummaryData;
 }
 
 const GameSummary: React.FC<GameProps> = ({ game }) => {

--- a/src/components/GameSummary.tsx
+++ b/src/components/GameSummary.tsx
@@ -2,28 +2,53 @@
 import TeamLogos from "./TeamLogos";
 import {ArrowIconRight, ArrowIconLeft} from "./ArrowIcon";
 
+interface PeriodScore {
+  period: number;
+  score: string;
+}
+
 interface GameProps {
   game: {
     homeTeam: {
       teamId: number;
       teamTricode: string;
       teamName: string;
-      periods: Array<{period: number; score: string}>;
+      periods: PeriodScore[];
       score: string;
     };
     awayTeam: {
       teamId: number;
       teamTricode: string;
       teamName: string;
-      periods: Array<{period: number; score: string}>;
+      periods: PeriodScore[];
       score: string;
     };
     period: number;
     gameStatusText: string;
+    periodScoreSource?: "nba" | "basketball-reference" | "unavailable";
+    periodScoreType?: "quarters";
   };
 }
 
 const GameSummary: React.FC<GameProps> = ({ game }) => {
+  const homePeriods = game.homeTeam.periods ?? [];
+  const awayPeriods = game.awayTeam.periods ?? [];
+  const showPeriodScores = (
+    homePeriods.length > 0
+    && awayPeriods.length === homePeriods.length
+    && homePeriods.every((period, index) => period.period === awayPeriods[index]?.period)
+  );
+  const periodColumns = showPeriodScores ? homePeriods : [];
+
+  const periodHeader = (period: number) => {
+    if (period <= 4) return String(period);
+    return period === 5 ? "OT" : `OT${period - 4}`;
+  };
+
+  const findScoreForPeriod = (periods: PeriodScore[], period: number) => (
+    periods.find((periodScore) => periodScore.period === period)?.score ?? ""
+  );
+
   return (
     <div className="flex flex-col md:grid md:grid-cols-3 items-center gap-3 md:gap-4 p-4 rounded-lg dark:text-slate-50 text-neutral-950">
       <div className="flex md:hidden w-full justify-center items-center gap-8">
@@ -88,13 +113,9 @@ const GameSummary: React.FC<GameProps> = ({ game }) => {
             <thead>
               <tr>
                 <th className="text-left pl-1.5 md:pl-3 pr-2 md:pr-8"></th>
-                <th className="px-1 md:px-2 text-center">1</th>
-                <th className="px-1 md:px-2 text-center">2</th>
-                <th className="px-1 md:px-2 text-center">3</th>
-                <th className="px-1 md:px-2 text-center">4</th>
-                {game.homeTeam.periods.slice(4).map((p) => (
-                  <th className="px-1 md:px-2 text-center" key={`ot-header-${p.period}`}>
-                    OT{p.period - 4}
+                {periodColumns.map((period) => (
+                  <th className="px-1 md:px-2 text-center" key={`period-header-${period.period}`}>
+                    {periodHeader(period.period)}
                   </th>
                 ))}
                 <th className="px-1 md:px-2 text-center">T</th>
@@ -105,9 +126,9 @@ const GameSummary: React.FC<GameProps> = ({ game }) => {
                 <td className="text-left pl-1.5 md:pl-3 pr-1">
                   {game.homeTeam.teamTricode}
                 </td>
-                {game.homeTeam.periods.map((period) => (
+                {periodColumns.map((period) => (
                   <td className="px-1 md:px-2 text-center" key={period.period}>
-                    {period.score}
+                    {findScoreForPeriod(homePeriods, period.period)}
                   </td>
                 ))}
                 <td className="px-1 md:px-2 text-center font-bold">{game.homeTeam.score}</td>
@@ -116,9 +137,9 @@ const GameSummary: React.FC<GameProps> = ({ game }) => {
                 <td className="text-left pl-1.5 md:pl-3 pr-1">
                   {game.awayTeam.teamTricode}
                 </td>
-                {game.awayTeam.periods.map((period) => (
+                {periodColumns.map((period) => (
                   <td className="px-1 md:px-2 text-center" key={period.period}>
-                    {period.score}
+                    {findScoreForPeriod(awayPeriods, period.period)}
                   </td>
                 ))}
                 <td className="px-1 md:px-2 text-center font-bold">{game.awayTeam.score}</td>

--- a/src/helpers/helpers.tsx
+++ b/src/helpers/helpers.tsx
@@ -1,3 +1,29 @@
+export interface GameData {
+  gameId: string;
+  gameCode: string;
+  gameStatus: number;
+  gameLabel: string;
+  gameSubLabel: string;
+  gameTimeUTC: string;
+  gameStatusText: string;
+  ifNecessary: boolean;
+  seriesGameNumber: string;
+  seriesText: string;
+  boxscoreAvailable?: boolean;
+  homeTeam: {
+    teamName: string;
+    teamTricode: string;
+    teamId: number;
+    score: number;
+  };
+  awayTeam: {
+    teamName: string;
+    teamTricode: string;
+    teamId: number;
+    score: number;
+  };
+}
+
 export type Team = {
   teamName: string;
   teamTricode: string;
@@ -19,6 +45,32 @@ export type GameTeam = {
   name: string;
   score: number;
 };
+
+export type PeriodScore = {
+  period: number;
+  score: string;
+};
+
+export type PeriodScoreSource = "nba" | "basketball-reference" | "unavailable";
+
+export type PeriodScoreType = "quarters";
+
+export interface GameSummaryTeam {
+  teamId: number;
+  teamTricode: string;
+  teamName: string;
+  periods: PeriodScore[];
+  score: string;
+}
+
+export interface GameSummaryData {
+  homeTeam: GameSummaryTeam;
+  awayTeam: GameSummaryTeam;
+  period: number;
+  gameStatusText: string;
+  periodScoreSource?: PeriodScoreSource;
+  periodScoreType?: PeriodScoreType;
+}
 
 export type TeamsInSeries = {
   id: number;

--- a/src/helpers/helpers.tsx
+++ b/src/helpers/helpers.tsx
@@ -80,6 +80,7 @@ export type SeriesGame = {
   date: string;
   round: number;
   roundName: string;
+  boxscoreAvailable?: boolean;
   homeTeam: GameTeam;
   awayTeam: GameTeam;
   winnerTeamId: number | null;
@@ -198,9 +199,19 @@ export const placeholderTeamLogoUrl = "https://cdn.nba.com/logos/nba/fallback.sv
 
 export const placeholderPlayerHeadshot = "https://placehold.co/48x48?text=No+headshot";
 
-export function formatMinutesPlayed(minutesString: string) {
-  const minutes = parseInt(minutesString.match(/(\d+)M/)?.[1] || "0");
-  return minutes < 10 ? minutes.toString() : minutes.toString();
+export function formatMinutesPlayed(minutesString: string): string {
+  const normalizedMinutes = minutesString.trim();
+  if (normalizedMinutes.length === 0) return "0";
+
+  if (normalizedMinutes.includes(":")) {
+    const [minutes] = normalizedMinutes.split(":");
+    return minutes && /^\d+$/.test(minutes) ? minutes : "0";
+  }
+
+  if (/^\d+$/.test(normalizedMinutes)) return normalizedMinutes;
+
+  const minutesMatch = normalizedMinutes.match(/(\d+)M/);
+  return minutesMatch ? minutesMatch[1] : "0";
 }
 
 export const firstNameInitial = (playerName: string): string => {

--- a/src/routes/games/GameCard.tsx
+++ b/src/routes/games/GameCard.tsx
@@ -16,6 +16,7 @@ interface GameCardProps {
     ifNecessary: boolean;
     seriesGameNumber: string;
     seriesText: string;
+    boxscoreAvailable?: boolean;
     homeTeam: {
       teamName: string;
       teamTricode: string;
@@ -33,9 +34,12 @@ interface GameCardProps {
 
 function GameCard({game, showScores = false}: GameCardProps) {
   const gameHasStarted = game.gameStatus !== 1;
+  const shouldShowBoxscore =
+    showScores &&
+    gameHasStarted &&
+    game.gameId.length > 0 &&
+    game.boxscoreAvailable === true;
   const watchGameLink = generateWatchLink(game.awayTeam.teamTricode, game.homeTeam.teamTricode, game.gameId);
-  const endOf1819Season = new Date("2019-06-15T00:00:00Z");
-  const gameDateUtc = new Date(game.gameTimeUTC);
 
   return (
     <div className="flex justify-center lg:justify-start">
@@ -76,7 +80,7 @@ function GameCard({game, showScores = false}: GameCardProps) {
               ""
             ) : (
               <div className="flex flex-col gap-1">
-                {showScores && gameDateUtc >= endOf1819Season && (
+                {shouldShowBoxscore && (
                   <Link to={`/games/${game.gameId}/boxscore`}>Box score</Link>
                 )}
                 <Link to={`${watchGameLink}`} target="_blank">

--- a/src/routes/games/GameCard.tsx
+++ b/src/routes/games/GameCard.tsx
@@ -1,35 +1,11 @@
 import {Link} from "react-router-dom";
 import TeamLogos from "@/components/TeamLogos";
 import {generateWatchLink} from "@/helpers/helpers";
+import type {GameData} from "@/helpers/helpers";
 
 interface GameCardProps {
   showScores: boolean;
-  // dateParam: string;
-  game: {
-    gameId: string;
-    gameCode: string;
-    gameTimeUTC: string;
-    gameStatus: number;
-    gameStatusText: string;
-    gameLabel: string;
-    gameSubLabel: string;
-    ifNecessary: boolean;
-    seriesGameNumber: string;
-    seriesText: string;
-    boxscoreAvailable?: boolean;
-    homeTeam: {
-      teamName: string;
-      teamTricode: string;
-      score: number;
-      teamId: number;
-    };
-    awayTeam: {
-      teamName: string;
-      teamTricode: string;
-      score: number;
-      teamId: number;
-    };
-  };
+  game: GameData;
 }
 
 function GameCard({game, showScores = false}: GameCardProps) {

--- a/src/routes/games/Games.tsx
+++ b/src/routes/games/Games.tsx
@@ -16,6 +16,7 @@ type GameData = {
   ifNecessary: boolean;
   seriesGameNumber: string;
   seriesText: string;
+  boxscoreAvailable?: boolean;
   homeTeam: {
     teamName: string;
     teamTricode: string;
@@ -69,11 +70,11 @@ const Games = () => {
     queryKey: ["games", dateParam],
     queryFn: () => getScores(dateParam),
   });
+  const games = data?.games ?? [];
 
   if (isLoading) return <h1>Loading...</h1>;
   if (error) return <h1>{JSON.stringify(error)}</h1>;
   if (!data) return <h1>Didn't receive any games</h1>;
-  const {games} = data;
   return (
     <>
       {games.some((game) => game.gameStatus !== 1) && (

--- a/src/routes/games/Games.tsx
+++ b/src/routes/games/Games.tsx
@@ -4,32 +4,7 @@ import GameCard from "./GameCard.jsx";
 import {Switch} from "@adobe/react-spectrum";
 import {useSearchParams} from "react-router";
 import {setItem, getItem} from "@/helpers/helpers.jsx";
-
-type GameData = {
-  gameId: string;
-  gameCode: string;
-  gameStatus: number;
-  gameLabel: string;
-  gameSubLabel: string;
-  gameTimeUTC: string;
-  gameStatusText: string;
-  ifNecessary: boolean;
-  seriesGameNumber: string;
-  seriesText: string;
-  boxscoreAvailable?: boolean;
-  homeTeam: {
-    teamName: string;
-    teamTricode: string;
-    teamId: number;
-    score: number;
-  };
-  awayTeam: {
-    teamName: string;
-    teamTricode: string;
-    teamId: number;
-    score: number;
-  };
-};
+import type {GameData} from "@/helpers/helpers";
 
 const Games = () => {
   const [searchParams] = useSearchParams({date: ""});

--- a/src/routes/games/boxscore/Boxscore.tsx
+++ b/src/routes/games/boxscore/Boxscore.tsx
@@ -5,6 +5,7 @@ import DarkModeToggle from "@/components/DarkModeToggle";
 import PlayerTable from "./PlayerTable";
 // import InactivePlayers from "./InactivePlayers";
 import { getBoxScores, getGameSummary } from "@/services/nbaService";
+import type { GameSummaryData, GameSummaryTeam } from "@/helpers/helpers";
 
 interface BoxscoreTeam {
   teamId: number;
@@ -37,22 +38,24 @@ const Boxscore = () => {
     return <h1>Error loading boxscore data</h1>;
   }
 
-  const buildTeamFromBoxscore = (team: BoxscoreTeam) => ({
+  const buildTeamFromBoxscore = (team: BoxscoreTeam): GameSummaryTeam => ({
     teamId: team.teamId ?? 0,
     teamTricode: team.teamTricode ?? "",
     teamName: `${team.teamCity ?? ""} ${team.teamName ?? ""}`.trim(),
     score: String(team.statistics?.points ?? ""),
-    periods: [] as Array<{ period: number; score: string }>,
+    periods: [],
   });
 
-  const summaryData = gameSummaryQuery.data ?? (!gameSummaryQuery.isLoading && game ? {
+  const fallbackSummaryData: GameSummaryData | null = !gameSummaryQuery.isLoading && game ? {
     homeTeam: buildTeamFromBoxscore(game.homeTeam),
     awayTeam: buildTeamFromBoxscore(game.awayTeam),
     period: 0,
     gameStatusText: game.gameStatusText ?? "Unknown",
-    periodScoreSource: "unavailable" as const,
-    periodScoreType: "quarters" as const,
-  } : null);
+    periodScoreSource: "unavailable",
+    periodScoreType: "quarters",
+  } : null;
+
+  const summaryData = gameSummaryQuery.data ?? fallbackSummaryData;
 
   return (
     <div className="bg-slate-50 dark:bg-neutral-950 min-h-screen">

--- a/src/routes/games/boxscore/Boxscore.tsx
+++ b/src/routes/games/boxscore/Boxscore.tsx
@@ -27,15 +27,15 @@ const Boxscore = () => {
     queryFn: () => getGameSummary(gameId),
   });
 
-  if (boxscoreQuery.isLoading) {
+  if (boxscoreQuery.isLoading || (boxscoreQuery.isError && gameSummaryQuery.isLoading)) {
     return <h1>Loading...</h1>;
   }
 
-  if (boxscoreQuery.isError || !boxscoreQuery.data) {
+  const game = boxscoreQuery.data?.game;
+
+  if (!game && (gameSummaryQuery.isError || !gameSummaryQuery.data)) {
     return <h1>Error loading boxscore data</h1>;
   }
-
-  const { game } = boxscoreQuery.data;
 
   const buildTeamFromBoxscore = (team: BoxscoreTeam) => ({
     teamId: team.teamId ?? 0,
@@ -45,19 +45,29 @@ const Boxscore = () => {
     periods: [] as Array<{ period: number; score: string }>,
   });
 
-  const summaryData = gameSummaryQuery.data ?? (!gameSummaryQuery.isLoading ? {
+  const summaryData = gameSummaryQuery.data ?? (!gameSummaryQuery.isLoading && game ? {
     homeTeam: buildTeamFromBoxscore(game.homeTeam),
     awayTeam: buildTeamFromBoxscore(game.awayTeam),
     period: 0,
     gameStatusText: game.gameStatusText ?? "Unknown",
+    periodScoreSource: "unavailable" as const,
+    periodScoreType: "quarters" as const,
   } : null);
 
   return (
-    <div className="bg-slate-50 dark:bg-neutral-950">
+    <div className="bg-slate-50 dark:bg-neutral-950 min-h-screen">
       <DarkModeToggle />
       {summaryData && <GameSummary game={summaryData} />}
-      <PlayerTable team={game.homeTeam} />
-      <PlayerTable team={game.awayTeam} />
+      {game ? (
+        <>
+          <PlayerTable team={game.homeTeam} />
+          <PlayerTable team={game.awayTeam} />
+        </>
+      ) : (
+        <p className="px-4 pb-6 text-center text-sm text-neutral-700 dark:text-slate-300">
+          Player boxscore is unavailable for this game.
+        </p>
+      )}
       {/* <InactivePlayers game={game} /> */}
     </div>
   );

--- a/src/routes/playoffs/SeriesDetail.tsx
+++ b/src/routes/playoffs/SeriesDetail.tsx
@@ -25,6 +25,10 @@ function SeriesDetail() {
   };
   const { data, isLoading, error } = usePlayoffData(season);
   const model = useMemo(() => data ? buildPlayoffBracketModel(data) : null, [data]);
+  const series = useMemo(
+    () => model ? findSeriesBySlug(seriesSlug ?? '', model.series) : undefined,
+    [model, seriesSlug]
+  );
 
   if (!isValidYear) {
     return (
@@ -40,8 +44,6 @@ function SeriesDetail() {
   if (isLoading) return <p className="p-4 dark:text-slate-50">Loading...</p>;
   if (error) return <p className="p-4 dark:text-slate-50">Error: {String(error)}</p>;
   if (!data) return <p className="p-4 dark:text-slate-50">No data available</p>;
-
-  const series = model ? findSeriesBySlug(seriesSlug ?? '', model.series) : undefined;
 
   if (!series) {
     return (
@@ -127,13 +129,14 @@ function SeriesDetail() {
                 const gameDate = formatGameDate(game.date);
                 const homeWon = isRevealed && game.homeTeam.score > game.awayTeam.score;
                 const awayWon = isRevealed && game.awayTeam.score > game.homeTeam.score;
+                const boxscoreAvailable = game.boxscoreAvailable === true;
 
                 return (
                   <div
                     key={game.gameId}
                     className="relative text-sm text-gray-700 dark:text-slate-300 flex items-center gap-3 py-3"
                   >
-                    {isRevealed && (
+                    {isRevealed && boxscoreAvailable && (
                       <Link to={`/games/${game.gameId}/boxscore`} className="absolute inset-0 sm:hidden" aria-label="Box score" />
                     )}
                     <span className="text-gray-400 dark:text-gray-500 shrink-0 w-14">Game {index + 1}</span>
@@ -157,7 +160,7 @@ function SeriesDetail() {
                         Watch
                       </a>
                     )}
-                    {isRevealed && (
+                    {isRevealed && boxscoreAvailable && (
                       <>
                         <svg
                           className="sm:hidden shrink-0 text-gray-400 dark:text-gray-500"

--- a/src/services/nbaService.ts
+++ b/src/services/nbaService.ts
@@ -1,4 +1,4 @@
-import type { PlayoffBracketResponse } from "@/helpers/helpers";
+import type { GameSummaryData, PlayoffBracketResponse } from "@/helpers/helpers";
 
 const getBaseUrl = () => import.meta.env.DEV
   ? import.meta.env.VITE_API_URL_DEV
@@ -20,7 +20,7 @@ export const getBoxScores = async (gameId: string) => {
   return response.json();
 };
 
-export const getGameSummary = async (gameId: string) => {
+export const getGameSummary = async (gameId: string): Promise<GameSummaryData> => {
   const url = `${getBaseUrl()}/gamesummary/${gameId}`;
   const response = await fetch(url);
   if (!response.ok) throw new Error("Game summary fetch failed");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added box score availability indicators across game and playoff views, so links and controls appear only when data is actually available.
  * Improved game summaries with more reliable period-by-period scoring and clearer status display, including support for overtime games.

* **Bug Fixes**
  * Fixed box score and summary loading behavior when one data source is delayed or unavailable.
  * Improved minute formatting for player stats to handle more input formats consistently.

* **Documentation**
  * Updated README wording for clearer availability notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->