### PR TITLE
center content with the center of center court in the background

### DIFF
--- a/src/designs/DesignRoute.tsx
+++ b/src/designs/DesignRoute.tsx
@@ -49,7 +49,7 @@ function DesignRoute({designId, children}: DesignRouteProps) {
       data-design={designId}
       data-design-name={definition.name}
     >
-      <div className="design-route__content">{children}</div>
+      <div className="design-route__content switcher:px-[66px]">{children}</div>
       <DesignSwitcher activeDesign={designId} />
     </div>
   );

--- a/src/designs/base.css
+++ b/src/designs/base.css
@@ -256,10 +256,7 @@
 
 @keyframes concept-enter { from { opacity: 0; transform: translateY(18px); } }
 
-@media (min-width: 900px) {
-  .design-route__content { padding-right: 66px; }
-}
-
+/* keep in sync with --breakpoint-switcher in src/index.css */
 @media (max-width: 899px) {
   .design-switcher--desktop { display: none; }
   .design-switcher__mobile-trigger { position: fixed; z-index: 90; right: 14px; bottom: max(14px, env(safe-area-inset-bottom)); display: inline-flex; min-height: 44px; align-items: center; gap: 8px; padding: 0 14px; border: 1px solid rgb(255 255 255 / 25%); border-radius: 999px; background: var(--switcher-bg); color: var(--switcher-fg); box-shadow: 0 12px 32px rgb(0 0 0 / 30%); font: 800 11px/1 "Archivo", sans-serif; letter-spacing: .04em; }

--- a/src/designs/design-4/BoxscorePage.tsx
+++ b/src/designs/design-4/BoxscorePage.tsx
@@ -33,7 +33,7 @@ function HardwoodLeaders({game}: {game: {awayTeam: DesignBoxscoreTeam; homeTeam:
   return (
     <section className={hwContainer} aria-label="Top performers">
       <h2 className="mb-3 text-[13px] font-extrabold tracking-[.22em] uppercase">Top performers</h2>
-      <div className="grid grid-cols-2 gap-3 min-[900px]:grid-cols-4">
+      <div className="grid grid-cols-2 gap-3 switcher:grid-cols-4">
         {leaders.map(({team, player}) => (
           <article key={player.personId} className="grid grid-cols-[auto_1fr] items-center gap-x-3 gap-y-0.5 rounded-hw border border-hw-line bg-hw-surface px-4 py-3.5 shadow-hw-card max-[700px]:gap-x-2.5 max-[700px]:px-3 max-[700px]:py-[11px] [&_figure]:contents [&_img]:row-span-3 [&_img]:h-[38px] [&_img]:w-[52px] [&_img]:max-w-none [&_img]:object-contain max-[700px]:[&_img]:h-[32px] max-[700px]:[&_img]:w-[44px]">
             <PlayerHeadshot player={player} className="block place-self-center" />

--- a/src/designs/design-4/hardwood.css
+++ b/src/designs/design-4/hardwood.css
@@ -17,6 +17,7 @@
   --switcher-bg: #101010;
   --switcher-fg: #fff;
   --switcher-accent: #ffd524;
+  background: var(--hw-page);
 }
 
 .dark .design-hardwood {

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,10 @@
 @import "tailwindcss";
 @import "./designs/design-4/hardwood.css";
 
+@theme {
+  --breakpoint-switcher: 900px;
+}
+
 @custom-variant dark (&:where(.dark, .dark *));
 
 .react-flow__controls-button {


### PR DESCRIPTION
<img width="2872" height="1830" alt="image" src="https://github.com/user-attachments/assets/64fbcf31-7a3b-4519-bac1-82059c256174" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved responsive spacing around design route content.
  * Adjusted top-performers grid behavior for better layout switching.
  * Updated the Hardwood design’s page background styling.
  * Standardized responsive breakpoint handling across design layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->