### PR TITLE
improve visibility of playoff bracket lines in light mode

### DIFF
--- a/src/designs/design-4/hardwood.css
+++ b/src/designs/design-4/hardwood.css
@@ -9,6 +9,7 @@
   --hw-accent-ink: #7c5a00;
   --hw-accent-contrast: #131313;
   --hw-line: #ddd2b4;
+  --hw-bracket-line: #131210;
   --hw-winner-arrow: #1d8f46;
   --hw-shadow-card: 0 10px 26px rgb(43 29 6 / 14%);
   --hw-shadow-small: 0 5px 14px rgb(43 29 6 / 14%);
@@ -30,6 +31,7 @@
   --hw-accent: #ffd524;
   --hw-accent-ink: #ffd524;
   --hw-line: #2b2f28;
+  --hw-bracket-line: #f59e0b;
   --hw-winner-arrow: #43d97b;
   --hw-shadow-card: 0 18px 42px rgb(0 0 0 / 50%);
   --hw-shadow-small: 0 8px 22px rgb(0 0 0 / 45%);
@@ -48,6 +50,7 @@
   --color-hw-accent-ink: var(--hw-accent-ink);
   --color-hw-accent-contrast: var(--hw-accent-contrast);
   --color-hw-line: var(--hw-line);
+  --color-hw-bracket-line: var(--hw-bracket-line);
   --color-hw-winner-arrow: var(--hw-winner-arrow);
   --shadow-hw-card: var(--hw-shadow-card);
   --shadow-hw-small: var(--hw-shadow-small);

--- a/src/utils/bracketTransformer.ts
+++ b/src/utils/bracketTransformer.ts
@@ -194,7 +194,7 @@ function createBracketEdges(
       targetHandle,
       animated: false,
       style: {
-        stroke: '#f59e0b',
+        stroke: 'var(--hw-bracket-line, #f59e0b)',
         strokeWidth: 2,
       },
       type: 'bracketEdge',


### PR DESCRIPTION
<img width="541" height="516" alt="Screenshot 2026-08-14 at 6 14 17 PM" src="https://github.com/user-attachments/assets/c0975fd3-aad1-42e5-b377-50d459d7b289" />
